### PR TITLE
Add Settings UI

### DIFF
--- a/src/common/axios.js
+++ b/src/common/axios.js
@@ -1,9 +1,8 @@
 import axios from "axios";
 
-function setupAxios() {
-  if (process.env.NODE_ENV === "development") {
-    axios.defaults.baseURL = "http://localhost:6333";
-  }
+function setupAxios({ apiURL, apiKey }) {
+  axios.defaults.baseURL = apiURL;
+  axios.defaults.headers.common["api-key"] = apiKey;
 }
 
 export default setupAxios;

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -14,6 +14,7 @@ import { Logo } from "../components/Logo";
 import { Stack } from "@mui/material";
 import TerminalIcon from "@mui/icons-material/Terminal";
 import LibraryBooksIcon from "@mui/icons-material/LibraryBooks";
+import SettingsIcon from "@mui/icons-material/Settings";
 
 const drawerWidth = 240;
 
@@ -57,6 +58,12 @@ export default function Sidebar({ open }) {
                 <LibraryBooksIcon />
               </ListItemIcon>
               <ListItemText primary={"Collections"} />
+            </ListItemButton>
+            <ListItemButton key={"Settings"} component={Link} to="/settings">
+              <ListItemIcon>
+                <SettingsIcon />
+              </ListItemIcon>
+              <ListItemText primary={"Settings"} />
             </ListItemButton>
           </List>
         </Drawer>

--- a/src/context/settings.js
+++ b/src/context/settings.js
@@ -1,0 +1,44 @@
+import React, { useContext, createContext, useState, useEffect } from "react";
+import setupAxios from "../common/axios";
+
+const DEFAULT_URL = "http://localhost:6333";
+
+const DEFAULT_SETTINGS = {
+  apiURL: DEFAULT_URL,
+  apiKey: "",
+};
+
+//Write settings to local storage
+const persistSettings = (settings) => {
+  localStorage.setItem("settings", JSON.stringify(settings));
+};
+
+// Get existing Settings from Local Storage or set default values
+const getPersistedSettings = () => {
+  const settings = localStorage.getItem("settings");
+
+  if (settings) return JSON.parse(settings);
+
+  return DEFAULT_SETTINGS;
+};
+
+//React context to store the settings
+const SettingsContext = createContext();
+
+//React hook to access and modify the settings
+export const useSettings = () => useContext(SettingsContext);
+
+//Settings Context Provider
+export const SettingsProvider = (props) => {
+  //TODO: Switch to Reducer if we have more settings to track.
+  const [settings, setSettings] = useState(getPersistedSettings());
+
+  useEffect(() => {
+    setupAxios(settings);
+    persistSettings(settings);
+  }, [settings]);
+
+  return (
+    <SettingsContext.Provider value={{ settings, setSettings }} {...props} />
+  );
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,16 +3,16 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
-import setupAxios from "./common/axios";
 import { HashRouter } from "react-router-dom";
-
-setupAxios();
+import { SettingsProvider } from "./context/settings";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
     <HashRouter>
-      <App />
+      <SettingsProvider>
+        <App />
+      </SettingsProvider>
     </HashRouter>
   </React.StrictMode>
 );

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -1,0 +1,134 @@
+import Container from "@mui/material/Container";
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import FormControl from "@mui/material/FormControl";
+import TextField from "@mui/material/TextField";
+import Snackbar from "@mui/material/Snackbar";
+import Alert from "@mui/material/Alert";
+import Button from "@mui/material/Button";
+import React, { useEffect, useState } from "react";
+import { useSettings } from "../context/settings";
+import SaveIcon from "@mui/icons-material/Save";
+
+const DEFAULT_SETTINGS = {
+  apiURL: "",
+  apiKey: "",
+};
+
+const isValidURL = (userInputURL) => {
+  try {
+    let urlCheck = new URL(userInputURL);
+    if (urlCheck.protocol !== "http:" && urlCheck.protocol !== "https:") {
+      return "Please provide a valid Protocol: (Http or Https)";
+    }
+  } catch (e) {
+    return "Invalid URL";
+  }
+
+  return "";
+};
+
+const Settings = () => {
+  const { settings, setSettings } = useSettings();
+  const [settingForm, setSettingForm] = useState(DEFAULT_SETTINGS);
+  const [toast, setToast] = useState(false);
+  const error = isValidURL(settingForm.apiURL);
+  console.log(error);
+  useEffect(() => {
+    setSettingForm({
+      ...settings,
+    });
+  }, [settings]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (error) {
+      setToast(true);
+      return;
+    }
+    let apiURL = new URL(settingForm.apiURL); //Clean URL
+    setSettings({ ...settingForm, apiURL: apiURL.toString() });
+    setToast(true);
+  };
+
+  const handleChange = (e) => {
+    const { value, name } = e.target;
+
+    setSettingForm((prevForm) => ({
+      ...prevForm,
+      [name]: value,
+    }));
+  };
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: "flex",
+        }}
+      >
+        <Container maxWidth="xl">
+          <Stack spacing={3}>
+            <Typography variant="h4" fontWeight={"bold"}>
+              Settings
+            </Typography>
+            <form onSubmit={handleSubmit}>
+              <FormControl fullWidth sx={{ m: 1 }}>
+                <TextField
+                  id="api-endpoint"
+                  label="API Endpoint"
+                  name="apiURL"
+                  required
+                  error={!!error}
+                  helperText={error}
+                  value={settingForm.apiURL}
+                  onChange={handleChange}
+                />
+              </FormControl>
+              <FormControl fullWidth sx={{ m: 1 }}>
+                <TextField
+                  id="api-key"
+                  label="API Key"
+                  name="apiKey"
+                  placeholder="Enter Qdrant API Key. Leave blank for local deployment."
+                  value={settingForm.apiKey}
+                  onChange={handleChange}
+                />
+              </FormControl>
+              <Button
+                type="submit"
+                sx={{ m: 1 }}
+                variant="outlined"
+                startIcon={<SaveIcon />}
+              >
+                Save
+              </Button>
+            </form>
+          </Stack>
+        </Container>
+        <Snackbar
+          anchorOrigin={{
+            vertical: "top",
+            horizontal: "right",
+          }}
+          open={toast}
+          autoHideDuration={6000}
+          onClose={() => setToast(false)}
+        >
+          {error ? (
+            <Alert severity="error" sx={{ width: "100%" }}>
+              {error}
+            </Alert>
+          ) : (
+            <Alert severity="success" sx={{ width: "100%" }}>
+              Settings saved successfully!
+            </Alert>
+          )}
+        </Snackbar>
+      </Box>
+    </>
+  );
+};
+
+export default Settings;

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,6 +3,7 @@ import Home from "./pages/Home";
 import Console from "./pages/Console";
 import Collections from "./pages/Collections";
 import Collection from "./pages/Collection";
+import Settings from "./pages/Settings";
 
 const routes = () => [
   {
@@ -12,6 +13,7 @@ const routes = () => [
       { path: "/console", element: <Console /> },
       { path: "/collections", element: <Collections /> },
       { path: "/collections/:collectionName", element: <Collection /> },
+      { path: "/settings", element: <Settings /> },
     ],
   },
 ];


### PR DESCRIPTION
- Created a New Page for Settings, with a Context to pass down the settings. 
- Currently, the settings support two fields, Custom Endpoint URL and API Key.
- This is useful to query Qdrant instances running on Qdrant Cloud Platform or other cloud services.

![image](https://user-images.githubusercontent.com/6051796/232247171-11d6098c-25da-4fd2-a56b-87bf44a661cc.png)

