### PR TITLE
correctly parse json with comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@vitejs/plugin-react": "^4.0.0",
         "autocomplete-openapi": "^0.1.0",
         "axios": "^1.3.4",
+        "jsonc-parser": "^3.2.0",
         "mui-chips-input": "^2.0.1",
         "openapi-client-axios": "^7.1.1",
         "prop-types": "^15.8.1",
@@ -3630,8 +3631,7 @@
     "node_modules/jsonc-parser": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.3",
@@ -7728,8 +7728,7 @@
     "jsonc-parser": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
     },
     "jsx-ast-utils": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@vitejs/plugin-react": "^4.0.0",
     "autocomplete-openapi": "^0.1.0",
     "axios": "^1.3.4",
+    "jsonc-parser": "^3.2.0",
     "mui-chips-input": "^2.0.1",
     "openapi-client-axios": "^7.1.1",
     "prop-types": "^15.8.1",

--- a/src/components/CodeEditorWindow/config/RequesFromCode.js
+++ b/src/components/CodeEditorWindow/config/RequesFromCode.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { parse as JsoncParse} from "jsonc-parser";
 
 export function RequestFromCode(text) {
   const data = codeParse(text);
@@ -42,7 +43,7 @@ export function codeParse(codeText) {
   var reqBody = {};
   if (body) {
     try {
-      reqBody = body === "\n" ? {} : JSON.parse(body);
+      reqBody = body === "\n" ? {} : JsoncParse(body);
     } catch (e) {
       return {
         method: null,

--- a/src/components/CodeEditorWindow/config/RequesFromCode.js
+++ b/src/components/CodeEditorWindow/config/RequesFromCode.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { parse as JsoncParse} from "jsonc-parser";
+import { parse as JsoncParse } from "jsonc-parser";
 
 export function RequestFromCode(text) {
   const data = codeParse(text);
@@ -34,16 +34,24 @@ export function RequestFromCode(text) {
 
 export function codeParse(codeText) {
   const codeArray = codeText.split(/\r?\n/);
-  const headerLine = codeArray.shift();
+  let headerLine = codeArray.shift();
+  // Remove possible comments
+  headerLine = headerLine.replace(/\/\/.*$/gm, "");
   const body = codeArray.join("\n");
   //Extract the header
   const method = headerLine.split(" ")[0];
   const endpoint = headerLine.split(" ")[1];
 
+  const parserConfig = {
+    allowTrailingComma: false,
+    disallowComments: false,
+    allowEmptyContent: false
+  };
+
   var reqBody = {};
   if (body) {
     try {
-      reqBody = body === "\n" ? {} : JsoncParse(body);
+      reqBody = body === "\n" ? {} : JsoncParse(body, null, parserConfig);
     } catch (e) {
       return {
         method: null,

--- a/src/components/EditorCommon/config/Rules.js
+++ b/src/components/EditorCommon/config/Rules.js
@@ -94,7 +94,7 @@ export function selectBlock(blocks, location) {
 }
 
 export function GetCodeBlocks(codeText) {
-  const codeArray = codeText.replace(/\/\/.*$/gm, "").split(/\r?\n/);
+  const codeArray = codeText.split(/\r?\n/);
   var blocksArray = [];
   var block = { blockText: "", blockStartLine: null, blockEndLine: null };
   var backetcount = 0;


### PR DESCRIPTION
Previous implementation failed on cases like:

```
{
  "a": "//b", // This is a comment.
  "c": "d" // Another comment
}
```

Fixed by using specialized jsonc parser