### PR TITLE
Unwanted scrollbar

### DIFF
--- a/src/components/CodeEditorWindow/Menu/history.jsx
+++ b/src/components/CodeEditorWindow/Menu/history.jsx
@@ -97,7 +97,6 @@ function History({ state, code, handleEditorChange, toggleDrawer }) {
         <Box
           sx={{
             width: "100%",
-            height: "100%",
             display: "flex",
             mt: 8,
           }}
@@ -105,9 +104,6 @@ function History({ state, code, handleEditorChange, toggleDrawer }) {
           <Box
             sx={{
               width: "60%",
-              height: "100%",
-              overflow: "hidden",
-              overflowY: "scroll",
             }}
           >
             <Stack direction="row" spacing={2}>
@@ -168,7 +164,6 @@ function History({ state, code, handleEditorChange, toggleDrawer }) {
           <Box
             sx={{
               width: "40%",
-              height: "100%",
             }}
             m={2}
           >

--- a/src/components/CodeEditorWindow/Menu/savedCode.jsx
+++ b/src/components/CodeEditorWindow/Menu/savedCode.jsx
@@ -106,7 +106,6 @@ function SavedCode({ state, code, handleEditorChange, toggleDrawer }) {
         <Box
           sx={{
             width: "100%",
-            height: "100%",
             display: "flex",
             mt: 8,
           }}
@@ -114,9 +113,6 @@ function SavedCode({ state, code, handleEditorChange, toggleDrawer }) {
           <Box
             sx={{
               width: "60%",
-              height: "100%",
-              overflow: "hidden",
-              overflowY: "scroll",
             }}
           >
             <Typography variant="h5" m={2} gutterBottom>
@@ -182,7 +178,6 @@ function SavedCode({ state, code, handleEditorChange, toggleDrawer }) {
           <Box
             sx={{
               width: "40%",
-              height: "100%",
             }}
             m={2}
           >


### PR DESCRIPTION
This PR gets rid of the middle vertical scrollbars in the `History` and `SavedCode` drawers