### PR TITLE
Point images fix - removed the wrong condition

### DIFF
--- a/src/components/Points/PointCard.jsx
+++ b/src/components/Points/PointCard.jsx
@@ -108,7 +108,7 @@ const PointCard = (props) => {
                 <Grid item xs my={1}>
                   <PointPayloadList data={point} />
                 </Grid>
-                {point.payload.images && (
+                {point.payload && (
                   <Grid item xs={3} display="grid" justifyContent={'center'}>
                     <PointImage data={point.payload} sx={{ ml: 2 }} />
                   </Grid>


### PR DESCRIPTION
In my previous commits, I mistakenly assumed that image URLs were always located in the `mages` payload key.  This PR fixes this error (removed the wrong condition).