### PR TITLE
Fixed consistency of alerts appearance

### DIFF
--- a/src/components/Common/CopyButton.jsx
+++ b/src/components/Common/CopyButton.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { IconButton, Tooltip } from '@mui/material';
+import { CopyAll } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
+import { getSnackbarOptions } from './utils/snackbarOptions';
+
+export const CopyButton = ({ text, tooltip, tooltipPlacement, successMessage }) => {
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+  const successSnackbarOptions = getSnackbarOptions('success', closeSnackbar, 1000);
+  const errorSnackbarOptions = getSnackbarOptions('error', closeSnackbar);
+
+  return (
+    <Tooltip title={tooltip} placement={tooltipPlacement}>
+      <IconButton
+        aria-label={tooltip}
+        onClick={() => {
+          navigator.clipboard
+            .writeText(text)
+            .then(() => {
+              enqueueSnackbar(successMessage, successSnackbarOptions);
+            })
+            .catch((err) => {
+              enqueueSnackbar(err.message, errorSnackbarOptions);
+            });
+        }}
+      >
+        <CopyAll />
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+CopyButton.defaultProps = {
+  tooltip: 'Copy to clipboard',
+  tooltipPlacement: 'left',
+  successMessage: 'Copied to clipboard',
+};
+
+CopyButton.propTypes = {
+  text: PropTypes.string.isRequired,
+  tooltip: PropTypes.string,
+  tooltipPlacement: PropTypes.string,
+  successMessage: PropTypes.string,
+};

--- a/src/components/Common/utils/snackbarOptions.jsx
+++ b/src/components/Common/utils/snackbarOptions.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Button } from '@mui/material';
+
+export const getSnackbarOptions = (variant, closeSnackbar, autoHideDuration = null) => ({
+  variant: variant,
+  autoHideDuration: autoHideDuration,
+  preventDuplicate: true,
+  action: (key) => (
+    <Button
+      variant="outlined"
+      color="inherit"
+      onClick={() => {
+        closeSnackbar(key);
+      }}
+    >
+      Dismiss
+    </Button>
+  ),
+});

--- a/src/components/Points/PayloadEditor.jsx
+++ b/src/components/Points/PayloadEditor.jsx
@@ -5,10 +5,13 @@ import { useSnackbar } from 'notistack';
 import isEqual from 'lodash/isEqual';
 import { Button, Dialog, DialogActions, DialogTitle, DialogContent } from '@mui/material';
 import EditorCommon from '../EditorCommon';
+import { getSnackbarOptions } from '../Common/utils/snackbarOptions';
 
 export const PayloadEditor = memo(({ collectionName, point, open, onClose, onSave, setLoading }) => {
   const { client: qdrantClient } = useClient();
-  const { enqueueSnackbar } = useSnackbar();
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+  const errorSnackbarOptions = getSnackbarOptions('error', closeSnackbar, 6000);
+  const successSnackbarOptions = getSnackbarOptions('success', closeSnackbar, 2000);
   const [payload, setPayload] = useState(() => JSON.stringify(point.payload, null, 2));
 
   const savePayload = async (collectionName, options) => {
@@ -27,11 +30,7 @@ export const PayloadEditor = memo(({ collectionName, point, open, onClose, onSav
     try {
       payloadToSave = JSON.parse(payload);
     } catch (e) {
-      enqueueSnackbar(e.message, {
-        variant: 'error',
-        autoHideDuration: 2500,
-        anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
-      });
+      enqueueSnackbar(e.message, errorSnackbarOptions);
       return;
     }
 
@@ -54,21 +53,13 @@ export const PayloadEditor = memo(({ collectionName, point, open, onClose, onSav
         if (onSave && res.status === 'completed') {
           onSave(payloadToSave);
 
-          enqueueSnackbar('Payload saved', {
-            variant: 'success',
-            autoHideDuration: 1500,
-            anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
-          });
+          enqueueSnackbar('Payload saved', successSnackbarOptions);
         }
       })
       .catch((err) => {
         // rollback payload and show error
         onSave && onSave(oldPayload);
-        enqueueSnackbar(err.message, {
-          variant: 'error',
-          autoHideDuration: 3000,
-          anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
-        });
+        enqueueSnackbar(err.message, errorSnackbarOptions);
       })
       .finally(() => {
         // stop loading state and show success message

--- a/src/components/Points/PointCard.jsx
+++ b/src/components/Points/PointCard.jsx
@@ -1,24 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Card, CardContent, Grid, CardHeader, Snackbar, Alert, LinearProgress, Box } from '@mui/material';
+import { Card, CardContent, Grid, CardHeader, LinearProgress, Box } from '@mui/material';
 
 import PointImage from './PointImage';
 import { alpha } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import CopyAll from '@mui/icons-material/CopyAll';
 import Edit from '@mui/icons-material/Edit';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import Vectors from './PointVectors';
 import { PayloadEditor } from './PayloadEditor';
 import { PointPayloadList } from './PointPayloadList';
+import { CopyButton } from '../Common/CopyButton';
 
 const PointCard = (props) => {
   const theme = useTheme();
   const { setRecommendationIds } = props;
   const [point, setPoint] = React.useState(props.point);
   const [openPayloadEditor, setOpenPayloadEditor] = React.useState(false);
-  const [openSnackbar, setOpenSnackbar] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
 
   const onPayloadEdit = (payload) => {
@@ -59,18 +58,11 @@ const PointCard = (props) => {
                   </IconButton>
                 </Tooltip>
               )}
-
-              <Tooltip title="Copy Point" placement="left">
-                <IconButton
-                  aria-label="copy point"
-                  onClick={() => {
-                    navigator.clipboard.writeText(JSON.stringify(point));
-                    setOpenSnackbar(true);
-                  }}
-                >
-                  <CopyAll />
-                </IconButton>
-              </Tooltip>
+              <CopyButton
+                text={JSON.stringify(point)}
+                tooltip={'Copy point to clipboard'}
+                successMessage={'Point JSON copied to clipboard.'}
+              />
             </>
           }
         />
@@ -89,17 +81,11 @@ const PointCard = (props) => {
                       <Edit />
                     </IconButton>
                   </Tooltip>
-                  <Tooltip title="Copy Payload" placement="left">
-                    <IconButton
-                      aria-label="copy point payload"
-                      onClick={() => {
-                        navigator.clipboard.writeText(JSON.stringify(point.payload));
-                        setOpenSnackbar(true);
-                      }}
-                    >
-                      <CopyAll />
-                    </IconButton>
-                  </Tooltip>
+                  <CopyButton
+                    text={JSON.stringify(point.payload)}
+                    tooltip={'Copy payload to clipboard'}
+                    successMessage={'Payload JSON copied to clipboard.'}
+                  />
                 </>
               }
             />
@@ -125,9 +111,7 @@ const PointCard = (props) => {
           }}
         />
         <CardContent>
-          {point?.vector && (
-            <Vectors point={point} setRecommendationIds={setRecommendationIds} onCopy={() => setOpenSnackbar(true)} />
-          )}
+          {point?.vector && <Vectors point={point} setRecommendationIds={setRecommendationIds} />}
         </CardContent>
       </Card>
       <PayloadEditor
@@ -140,17 +124,6 @@ const PointCard = (props) => {
         onSave={onPayloadEdit}
         setLoading={setLoading}
       />
-      <Snackbar
-        open={openSnackbar}
-        severity="success"
-        autoHideDuration={3000}
-        onClose={() => setOpenSnackbar(false)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert severity="success" sx={{ width: '100%' }}>
-          JSON copied to clipboard.
-        </Alert>
-      </Snackbar>
     </>
   );
 };

--- a/src/components/Points/PointVectors.jsx
+++ b/src/components/Points/PointVectors.jsx
@@ -1,9 +1,7 @@
 import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Chip, Grid, Typography } from '@mui/material';
-import IconButton from '@mui/material/IconButton';
-import { CopyAll } from '@mui/icons-material';
-import Tooltip from '@mui/material/Tooltip';
+import { CopyButton } from '../Common/CopyButton';
 
 /**
  * Component for displaying vectors of a point
@@ -11,7 +9,7 @@ import Tooltip from '@mui/material/Tooltip';
  * @returns {JSX.Element|null}
  * @constructor
  */
-const Vectors = memo(function Vectors({ point, setRecommendationIds, onCopy }) {
+const Vectors = memo(function Vectors({ point, setRecommendationIds }) {
   if (!Object.getOwnPropertyDescriptor(point, 'vector')) {
     return null;
   }
@@ -43,17 +41,12 @@ const Vectors = memo(function Vectors({ point, setRecommendationIds, onCopy }) {
                   <Chip label={key} size="small" variant="outlined" sx={{ mr: 1 }} />
                 </>
               )}
-              <Tooltip title="Copy Vector" placement="right">
-                <IconButton
-                  aria-label={`copy vector ${key}`}
-                  onClick={() => {
-                    navigator.clipboard.writeText(JSON.stringify(vectors[key]));
-                    if (typeof onCopy === 'function') onCopy();
-                  }}
-                >
-                  <CopyAll />
-                </IconButton>
-              </Tooltip>
+              <CopyButton
+                text={JSON.stringify(vectors[key])}
+                tooltip={'Copy vector to clipboard'}
+                tooltipPlacement={'right'}
+                successMessage={`Copied ${key === '' ? 'default vector' : 'vector ' + key} to clipboard`}
+              />
             </Grid>
 
             <Grid item xs={4} my={1}>
@@ -85,7 +78,6 @@ const Vectors = memo(function Vectors({ point, setRecommendationIds, onCopy }) {
 Vectors.propTypes = {
   point: PropTypes.object.isRequired,
   setRecommendationIds: PropTypes.func.isRequired,
-  onCopy: PropTypes.func,
 };
 
 export default Vectors;

--- a/src/components/Snapshots/SnapshotsTab.jsx
+++ b/src/components/Snapshots/SnapshotsTab.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useClient } from '../../context/client-context';
 import { useSnackbar } from 'notistack';
+import { getSnackbarOptions } from '../Common/utils/snackbarOptions';
 import { Button, Grid, TableCell, TableContainer, TableRow, Typography } from '@mui/material';
 import PhotoCamera from '@mui/icons-material/PhotoCamera';
 import { TableWithGaps, TableHeadWithGaps, TableBodyWithGaps } from '../Common/TableWithGaps';
@@ -12,26 +13,7 @@ export const SnapshotsTab = ({ collectionName }) => {
   const [snapshots, setSnapshots] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
-
-  const errorSnackbarOptions = {
-    variant: 'error',
-    autoHideDuration: null,
-    action: (key) => (
-      <Button
-        variant="outlined"
-        color="inherit"
-        onClick={() => {
-          closeSnackbar(key);
-        }}
-      >
-        Dismiss
-      </Button>
-    ),
-    anchorOrigin: {
-      vertical: 'bottom',
-      horizontal: 'center',
-    },
-  };
+  const errorSnackbarOptions = getSnackbarOptions('error', closeSnackbar);
 
   useEffect(() => {
     setIsLoading(true);
@@ -73,6 +55,7 @@ export const SnapshotsTab = ({ collectionName }) => {
       .deleteSnapshot(collectionName, snapshotName)
       .then(() => {
         setSnapshots([...snapshots.filter((snapshot) => snapshot.name !== snapshotName)]);
+        enqueueSnackbar('Snapshot successfully deleted', getSnackbarOptions('success', closeSnackbar, 2000));
       })
       .catch((err) => {
         enqueueSnackbar(err.message, errorSnackbarOptions);

--- a/src/components/ToastNotifications/ErrorNotifier.jsx
+++ b/src/components/ToastNotifications/ErrorNotifier.jsx
@@ -1,50 +1,25 @@
-import React, { useState } from 'react';
-import Snackbar from '@mui/material/Snackbar';
-import MuiAlert from '@mui/material/Alert';
-import Slide from '@mui/material/Slide';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useSnackbar } from 'notistack';
+import { getSnackbarOptions } from '../Common/utils/snackbarOptions';
 
-const Alert = React.forwardRef((props, ref) => {
-  return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
-});
+export const ErrorNotifier = ({ message }) => {
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+  const errorSnackbarOptions = getSnackbarOptions('error', closeSnackbar, 6000);
 
-Alert.displayName = 'Alert';
+  useEffect(() => {
+    enqueueSnackbar(message, errorSnackbarOptions);
+  }, [enqueueSnackbar, errorSnackbarOptions, message]);
 
-function SlideTransition(props) {
-  return <Slide {...props} direction="down" />;
-}
+  return null;
+};
 
-function ErrorNotifier({ message }) {
-  const [open, setOpen] = useState(true);
-
-  const handleClose = (event, reason) => {
-    if (reason === 'clickaway') {
-      return;
-    }
-    setOpen(false);
-  };
-
-  return (
-    <>
-      <Snackbar
-        open={open}
-        autoHideDuration={6000}
-        onClose={handleClose}
-        disableWindowBlurListener
-        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-        TransitionComponent={SlideTransition}
-      >
-        <Alert onClose={handleClose} severity="error" sx={{ width: '100%' }}>
-          {message}
-        </Alert>
-      </Snackbar>
-    </>
-  );
-}
+ErrorNotifier.defaultProps = {
+  message: 'We are sorry, but something went wrong. Please, try again later.',
+};
 
 ErrorNotifier.propTypes = {
   message: PropTypes.string,
-  setHasError: PropTypes.func,
 };
 
 export default ErrorNotifier;

--- a/src/components/VisualizeChart/ViewPointModal.jsx
+++ b/src/components/VisualizeChart/ViewPointModal.jsx
@@ -1,27 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Alert,
-  Box,
-  Button,
-  Dialog,
-  DialogContent,
-  DialogActions,
-  DialogTitle,
-  IconButton,
-  Paper,
-  Tooltip,
-  Typography,
-  Snackbar,
-} from '@mui/material';
+import { Box, Button, Dialog, DialogContent, DialogActions, DialogTitle, Paper, Typography } from '@mui/material';
 import { alpha } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { CopyAll } from '@mui/icons-material';
 import { PointPayloadList } from '../Points/PointPayloadList';
+import { CopyButton } from '../Common/CopyButton';
 
 const ViewPointModal = (props) => {
   const theme = useTheme();
-  const [openTooltip, setOpenTooltip] = React.useState(false);
   const { openViewPoints, setOpenViewPoints, viewPoints } = props;
 
   return (
@@ -53,17 +39,7 @@ const ViewPointModal = (props) => {
                         Point {point.id}
                       </Typography>
 
-                      <Tooltip title="Copy JSON" placement="left">
-                        <IconButton
-                          aria-label="copy point"
-                          onClick={() => {
-                            navigator.clipboard.writeText(JSON.stringify(point));
-                            setOpenTooltip(true);
-                          }}
-                        >
-                          <CopyAll />
-                        </IconButton>
-                      </Tooltip>
+                      <CopyButton text={JSON.stringify(point)} />
                     </Box>
                     <Box px={3} pt={1} pb={5}>
                       <PointPayloadList data={point} sx={{ px: 3, py: 4 }} />
@@ -82,11 +58,6 @@ const ViewPointModal = (props) => {
           <Button onClick={() => setOpenViewPoints(false)}>Close</Button>
         </DialogActions>
       </Dialog>
-      <Snackbar open={openTooltip} severity="success" autoHideDuration={3000} onClose={() => setOpenTooltip(false)}>
-        <Alert severity="success" sx={{ width: '100%' }}>
-          Point JSON copied to clipboard.
-        </Alert>
-      </Snackbar>
     </>
   );
 };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,7 +12,13 @@ root.render(
   <React.StrictMode>
     <HashRouter>
       <ClientProvider>
-        <SnackbarProvider>
+        <SnackbarProvider
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+          style={{ flexWrap: 'nowrap' }}
+        >
           <App />
         </SnackbarProvider>
       </ClientProvider>


### PR DESCRIPTION
We had inconsistent alert (aka snacks, aka toasts) formats across different areas. In this PR, all alerts are implemented using `notistack`, and the alert style is unified to maintain a consistent appearance.