### PR TITLE
Sort collections by name on dashboard page

### DIFF
--- a/src/pages/Collections.jsx
+++ b/src/pages/Collections.jsx
@@ -17,7 +17,7 @@ function Collections() {
   async function getCollectionsCall() {
     try {
       const collections = await qdrantClient.getCollections();
-      setRawCollections(collections.collections);
+      setRawCollections(collections.collections.sort((a, b) => a.name.localeCompare(b.name)));
       setErrorMessage(null);
     } catch (error) {
       setErrorMessage(error.message);


### PR DESCRIPTION
When running Qdrant in cluster mode, the results from the `/collections` endpoint isn't consistant (order of the collections could change). It gives a weird UX pattern where button can change position when reloading the page...

To make it more predictable I propose to sort the retrieved array using the name of the collection.

Sorry if it's not the best way to do it in JS, it's not my primary language :) 

Thanks,