### PR TITLE
Fix empty space on the collection point view when there are no images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2647,8 +2647,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.3.4",
-      "license": "MIT",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -9775,7 +9776,9 @@
       "version": "1.0.5"
     },
     "axios": {
-      "version": "1.3.4",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/src/components/Points/PointCard.jsx
+++ b/src/components/Points/PointCard.jsx
@@ -94,11 +94,7 @@ const PointCard = (props) => {
                 <Grid item xs my={1}>
                   <DataGridList data={point.payload} />
                 </Grid>
-                {point.payload && (
-                  <Grid item xs={3} display="grid" justifyContent={'center'}>
-                    <PointImage data={point.payload} sx={{ ml: 2 }} />
-                  </Grid>
-                )}
+                {point.payload && <PointImage data={point.payload} sx={{ ml: 2 }} />}
               </Grid>
             </CardContent>
           </>

--- a/src/components/Points/PointImage.jsx
+++ b/src/components/Points/PointImage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CardMedia } from '@mui/material';
+import { CardMedia, Grid } from '@mui/material';
 
 function PointImage({ data, sx }) {
   const renderImages = () => {
@@ -49,7 +49,17 @@ function PointImage({ data, sx }) {
     return images;
   };
 
-  return <>{renderImages()}</>;
+  const images = renderImages();
+
+  if (images.length === 0) {
+    return null;
+  }
+
+  return (
+    <Grid item xs={3} display="grid" justifyContent={'center'}>
+      {images}
+    </Grid>
+  );
 }
 PointImage.propTypes = {
   data: PropTypes.object.isRequired,


### PR DESCRIPTION
Fixed unnecessary space on the right side when a point has no images.

Before:
<img width="800" alt="Screenshot 2023-11-11 at 00 12 45" src="https://github.com/qdrant/qdrant-web-ui/assets/7085263/a87218d2-ceca-4923-8784-3f8cf9372e3b">

After:
<img width="800" alt="Screenshot 2023-11-11 at 00 13 35" src="https://github.com/qdrant/qdrant-web-ui/assets/7085263/8f757d4b-c56d-4e02-8729-fb9483676d37">
