### PR TITLE
Show an error on 403 only if API key exists but not valid

### DIFF
--- a/src/pages/Collections.jsx
+++ b/src/pages/Collections.jsx
@@ -20,7 +20,13 @@ function Collections() {
       setRawCollections(collections.collections.sort((a, b) => a.name.localeCompare(b.name)));
       setErrorMessage(null);
     } catch (error) {
-      setErrorMessage(error.message);
+      if (error.status === 403 || error.status === 401) {
+        if (qdrantClient.getApiKey()) {
+          setErrorMessage('Your API key is invalid. Please, set a new one.');
+        }
+      } else {
+        setErrorMessage(error.message);
+      }
       setRawCollections(null);
     }
   }


### PR DESCRIPTION
Before:

On the first visit to the Qdrant web UI (aka dashboard) collections page, the user could see a red error toast and an open dialog for inserting the API key at the same time.

After:

A user sees a red error message toast above the dialog only if they already inserted the API key but get 404|401. Otherwise, they see only open dialog.


It also fixes a problem with an empty error toast here [#257](https://github.com/qdrant/cloud-pm/issues/257)