### PR TITLE
Fix for cases when long URLs push images to the next line

### DIFF
--- a/src/components/Points/DataGridList.jsx
+++ b/src/components/Points/DataGridList.jsx
@@ -56,7 +56,8 @@ export const DataGridList = function ({ data = {}, specialCases = {} }) {
                 variant="subtitle1"
                 color="text.secondary"
                 display={'inline'}
-                sx={{ wordBreak: 'break-word' }}>
+                sx={{ wordBreak: 'break-word' }}
+              >
                 {'\t'} {data[key].toString()}
               </Typography>
             )}

--- a/src/components/Points/DataGridList.jsx
+++ b/src/components/Points/DataGridList.jsx
@@ -52,7 +52,11 @@ export const DataGridList = function ({ data = {}, specialCases = {} }) {
 
             {/* other types of values */}
             {typeof data[key] !== 'object' && !specialKeys.includes(key) && (
-              <Typography variant="subtitle1" color="text.secondary" display={'inline'}>
+              <Typography
+                variant="subtitle1"
+                color="text.secondary"
+                display={'inline'}
+                sx={{ wordBreak: 'break-word' }}>
                 {'\t'} {data[key].toString()}
               </Typography>
             )}


### PR DESCRIPTION
Tiny fix for this:

![image](https://github.com/qdrant/qdrant-web-ui/assets/7085263/5cf8ac40-5c51-4024-8e06-726e397bbf39)
