### PR TITLE
Fix: Incorrect Arrow Direction for Expanding Tutorials Menu

### DIFF
--- a/src/components/Sidebar/SidebarTutorialSection.jsx
+++ b/src/components/Sidebar/SidebarTutorialSection.jsx
@@ -69,7 +69,7 @@ export const SidebarTutorialSection = ({ isSidebarOpen }) => {
               display: isSidebarOpen ? 'block' : 'none',
             }}
           />
-          {isSidebarOpen && (collapsed ? <ExpandLess onClick={handleChange} /> : <ExpandMore onClick={handleChange} />)}
+          {isSidebarOpen && (collapsed ? <ExpandMore onClick={handleChange} /> : <ExpandLess onClick={handleChange} />)}
         </ListItemButton>
       </Tooltip>
       {isSidebarOpen && (


### PR DESCRIPTION
**Before:**
![before](https://github.com/qdrant/qdrant-web-ui/assets/130062020/acd1140c-ad61-49d9-a991-5f2251aa4271)

**After:**
![after](https://github.com/qdrant/qdrant-web-ui/assets/130062020/1f60fc3a-7942-42a8-acad-3008e6c1a5ec)
