### PR TITLE
Fix crash when snapshot description has no creation time

### DIFF
--- a/src/components/Snapshots/SnapshotsTab.jsx
+++ b/src/components/Snapshots/SnapshotsTab.jsx
@@ -104,7 +104,7 @@ export const SnapshotsTab = ({ collectionName }) => {
 
   const tableRows = snapshots.map((snapshot) => (
     <SnapshotsTableRow
-      key={snapshot.creation_time.valueOf()}
+      key={snapshot.creation_time?.valueOf() || 'unknown'}
       snapshot={snapshot}
       downloadSnapshot={downloadSnapshot}
       deleteSnapshot={deleteSnapshot}


### PR DESCRIPTION
A snapshot may have a `creation_time` that is `null`. This PR fixes a web UI crash when this is the case.

Without this PR loading the list of collection snapshots crashes the web UI rendering a fully white page. After this PR it'll show 'unknown': 
![image](https://github.com/qdrant/qdrant-web-ui/assets/856222/e0ea2183-a002-4e0a-a0ea-d3904d7058fa)
