### PR TITLE
Using API error messages in the interface

### DIFF
--- a/src/components/ToastNotifications/ErrorNotifier.jsx
+++ b/src/components/ToastNotifications/ErrorNotifier.jsx
@@ -3,23 +3,21 @@ import PropTypes from 'prop-types';
 import { useSnackbar } from 'notistack';
 import { getSnackbarOptions } from '../Common/utils/snackbarOptions';
 
-export const ErrorNotifier = ({ message }) => {
+export const ErrorNotifier = ({ message = 'Something went wrong', callback }) => {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
   const errorSnackbarOptions = getSnackbarOptions('error', closeSnackbar, 6000);
 
   useEffect(() => {
     enqueueSnackbar(message, errorSnackbarOptions);
+    typeof callback === 'function' && callback();
   }, [enqueueSnackbar, errorSnackbarOptions, message]);
 
   return null;
 };
 
-ErrorNotifier.defaultProps = {
-  message: 'We are sorry, but something went wrong. Please, try again later.',
-};
-
 ErrorNotifier.propTypes = {
   message: PropTypes.string,
+  callback: PropTypes.func,
 };
 
 export default ErrorNotifier;

--- a/src/lib/get-error-message.js
+++ b/src/lib/get-error-message.js
@@ -1,0 +1,34 @@
+/**
+ * Get error message from error object
+ * @param {Error} e - error object
+ * @param {?Object} [options] - options: {defaultMessage: string, withApiKey: {apiKey: string}}
+ * @param {?string} [options.fallbackMessage] - fallback error message
+ * @param {?Object} [options.withApiKey] - object with apiKey
+ * @param {?string} [options.withApiKey.apiKey] - apiKey
+ * @return {null|string}
+ */
+export const getErrorMessage = (e, options = {}) => {
+  const {
+    fallbackMessage = "Something went wrong.",
+    withApiKey = null,
+  } = options;
+  const { apiKey } = withApiKey || {};
+  let message;
+
+  try {
+    // error is instance of ApiError
+    const error = e.getActualType();
+    if ((error.status === 401 || error.status === 403) && withApiKey) {
+      if (!apiKey) {
+        return null;
+      } else {
+        return "Your API key is invalid. Please, set a new one.";
+      }
+    }
+    message = error.data?.status?.error || e.message || fallbackMessage;
+  } catch (err) {
+    // error is not instance of ApiError
+    message = e.message || fallbackMessage;
+  }
+  return message;
+};

--- a/src/lib/get-error-message.js
+++ b/src/lib/get-error-message.js
@@ -8,10 +8,7 @@
  * @return {null|string}
  */
 export const getErrorMessage = (e, options = {}) => {
-  const {
-    fallbackMessage = "Something went wrong.",
-    withApiKey = null,
-  } = options;
+  const { fallbackMessage = 'Something went wrong.', withApiKey = null } = options;
   const { apiKey } = withApiKey || {};
   let message;
 
@@ -22,7 +19,7 @@ export const getErrorMessage = (e, options = {}) => {
       if (!apiKey) {
         return null;
       } else {
-        return "Your API key is invalid. Please, set a new one.";
+        return 'Your API key is invalid. Please, set a new one.';
       }
     }
     message = error.data?.status?.error || e.message || fallbackMessage;

--- a/src/pages/Collection.jsx
+++ b/src/pages/Collection.jsx
@@ -9,6 +9,7 @@ import { CenteredFrame } from '../components/Common/CenteredFrame';
 import Box from '@mui/material/Box';
 import { SnapshotsTab } from '../components/Snapshots/SnapshotsTab';
 import CollectionInfo from '../components/Collections/CollectionInfo';
+import { getErrorMessage } from "../lib/get-error-message";
 
 function Collection() {
   const pageSize = 10;
@@ -58,7 +59,8 @@ function Collection() {
           setPoints({ points: newPoints });
           setErrorMessage(null);
         } catch (error) {
-          setErrorMessage(error.message);
+          const message = getErrorMessage(error, { withApiKey: {apiKey: qdrantClient.getApiKey()}});
+          message && setErrorMessage(message);
           setPoints({});
         }
       } else {
@@ -75,7 +77,8 @@ function Collection() {
           setNextPageOffset(newPoints?.next_page_offset);
           setErrorMessage(null);
         } catch (error) {
-          setErrorMessage(error.message);
+          const message = getErrorMessage(error, { withApiKey: {apiKey: qdrantClient.getApiKey()}});
+          message && setErrorMessage(message);
           setPoints({});
         }
       }

--- a/src/pages/Collection.jsx
+++ b/src/pages/Collection.jsx
@@ -9,7 +9,7 @@ import { CenteredFrame } from '../components/Common/CenteredFrame';
 import Box from '@mui/material/Box';
 import { SnapshotsTab } from '../components/Snapshots/SnapshotsTab';
 import CollectionInfo from '../components/Collections/CollectionInfo';
-import { getErrorMessage } from "../lib/get-error-message";
+import { getErrorMessage } from '../lib/get-error-message';
 
 function Collection() {
   const pageSize = 10;
@@ -59,7 +59,7 @@ function Collection() {
           setPoints({ points: newPoints });
           setErrorMessage(null);
         } catch (error) {
-          const message = getErrorMessage(error, { withApiKey: {apiKey: qdrantClient.getApiKey()}});
+          const message = getErrorMessage(error, { withApiKey: { apiKey: qdrantClient.getApiKey() } });
           message && setErrorMessage(message);
           setPoints({});
         }
@@ -77,7 +77,7 @@ function Collection() {
           setNextPageOffset(newPoints?.next_page_offset);
           setErrorMessage(null);
         } catch (error) {
-          const message = getErrorMessage(error, { withApiKey: {apiKey: qdrantClient.getApiKey()}});
+          const message = getErrorMessage(error, { withApiKey: { apiKey: qdrantClient.getApiKey() } });
           message && setErrorMessage(message);
           setPoints({});
         }

--- a/src/pages/Collections.jsx
+++ b/src/pages/Collections.jsx
@@ -6,7 +6,7 @@ import { Typography, Grid } from '@mui/material';
 import ErrorNotifier from '../components/ToastNotifications/ErrorNotifier';
 import { CenteredFrame } from '../components/Common/CenteredFrame';
 import { SnapshotsUpload } from '../components/Snapshots/SnapshotsUpload';
-import { getErrorMessage } from "../lib/get-error-message";
+import { getErrorMessage } from '../lib/get-error-message';
 
 function Collections() {
   const [rawCollections, setRawCollections] = useState(null);
@@ -22,7 +22,7 @@ function Collections() {
       setErrorMessage(null);
     } catch (error) {
       const apiKey = qdrantClient.getApiKey();
-      const message = getErrorMessage(error, { withApiKey: {apiKey}});
+      const message = getErrorMessage(error, { withApiKey: { apiKey } });
       message && setErrorMessage(message);
       setRawCollections(null);
     }

--- a/src/pages/Collections.jsx
+++ b/src/pages/Collections.jsx
@@ -6,6 +6,7 @@ import { Typography, Grid } from '@mui/material';
 import ErrorNotifier from '../components/ToastNotifications/ErrorNotifier';
 import { CenteredFrame } from '../components/Common/CenteredFrame';
 import { SnapshotsUpload } from '../components/Snapshots/SnapshotsUpload';
+import { getErrorMessage } from "../lib/get-error-message";
 
 function Collections() {
   const [rawCollections, setRawCollections] = useState(null);
@@ -20,13 +21,9 @@ function Collections() {
       setRawCollections(collections.collections.sort((a, b) => a.name.localeCompare(b.name)));
       setErrorMessage(null);
     } catch (error) {
-      if (error.status === 403 || error.status === 401) {
-        if (qdrantClient.getApiKey()) {
-          setErrorMessage('Your API key is invalid. Please, set a new one.');
-        }
-      } else {
-        setErrorMessage(error.message);
-      }
+      const apiKey = qdrantClient.getApiKey();
+      const message = getErrorMessage(error, { withApiKey: {apiKey}});
+      message && setErrorMessage(message);
       setRawCollections(null);
     }
   }
@@ -42,7 +39,7 @@ function Collections() {
   return (
     <>
       <CenteredFrame>
-        {errorMessage !== null && <ErrorNotifier {...{ message: errorMessage }} />}
+        {errorMessage !== null && <ErrorNotifier message={errorMessage} />}
         <Grid container maxWidth={'xl'} spacing={3}>
           <Grid xs={12} item>
             <Typography variant="h4">Collections</Typography>


### PR DESCRIPTION
Previously, we did not incorporate error messages from the API into the toast messages displayed in the user interface. Consequently, at times, users were shown empty error toasts. This PR modifies this behavior and resolves the issue.