### PR TITLE
Auto-Complete Required Request Body Parameters when Inserting Commands

### DIFF
--- a/src/components/CodeEditorWindow/Menu/CommandsDrawer/CommandsDrawer.jsx
+++ b/src/components/CodeEditorWindow/Menu/CommandsDrawer/CommandsDrawer.jsx
@@ -7,19 +7,7 @@ import Close from '@mui/icons-material/Close';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useSnackbar } from 'notistack';
 import { getSnackbarOptions } from '../../../Common/utils/snackbarOptions';
-
-const resolveRequiredParams = function (openapi, requestBodyContent) {
-  const contentType = Object.keys(requestBodyContent)[0];
-  if ('$ref' in requestBodyContent[contentType].schema) {
-    const refPath = requestBodyContent[contentType].schema.$ref;
-    // parse and navigate to the ref
-    const pathComponents = refPath.slice(2).split('/');
-    const schema = pathComponents.reduce((doc, pathComponent) => doc[pathComponent], openapi);
-    return schema.required;
-  } else {
-    return requestBodyContent[contentType].schema.required;
-  }
-};
+import { resolveRequiredBodyParams } from '../../config/CommandsDrawerUtils';
 
 const CommandsDrawer = ({ open, toggleDrawer, handleInsertCommand }) => {
   const [allCommands, setAllCommands] = useState([]);
@@ -41,7 +29,7 @@ const CommandsDrawer = ({ open, toggleDrawer, handleInsertCommand }) => {
               const hasRequestBody = !!data.paths[path][method].requestBody;
               let requiredBodyParameters = null;
               if (hasRequestBody) {
-                requiredBodyParameters = resolveRequiredParams(data, data.paths[path][method].requestBody.content);
+                requiredBodyParameters = resolveRequiredBodyParams(data, data.paths[path][method].requestBody.content);
               }
 
               return {

--- a/src/components/CodeEditorWindow/Menu/CommandsDrawer/CommandsDrawer.jsx
+++ b/src/components/CodeEditorWindow/Menu/CommandsDrawer/CommandsDrawer.jsx
@@ -8,19 +8,18 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { useSnackbar } from 'notistack';
 import { getSnackbarOptions } from '../../../Common/utils/snackbarOptions';
 
-const resolveRequiredParams = function(openapi, requestBodyContent){
+const resolveRequiredParams = function (openapi, requestBodyContent) {
   const contentType = Object.keys(requestBodyContent)[0];
-  if ('$ref' in requestBodyContent[contentType].schema){
+  if ('$ref' in requestBodyContent[contentType].schema) {
     const refPath = requestBodyContent[contentType].schema.$ref;
     // parse and navigate to the ref
     const pathComponents = refPath.slice(2).split('/');
     const schema = pathComponents.reduce((doc, pathComponent) => doc[pathComponent], openapi);
     return schema.required;
-  }
-  else {
+  } else {
     return requestBodyContent[contentType].schema.required;
   }
-}
+};
 
 const CommandsDrawer = ({ open, toggleDrawer, handleInsertCommand }) => {
   const [allCommands, setAllCommands] = useState([]);
@@ -41,8 +40,8 @@ const CommandsDrawer = ({ open, toggleDrawer, handleInsertCommand }) => {
               const tags = data.paths[path][method].tags;
               const hasRequestBody = !!data.paths[path][method].requestBody;
               let requiredBodyParameters = null;
-              if (hasRequestBody){
-                requiredBodyParameters = resolveRequiredParams(data, data.paths[path][method].requestBody.content)
+              if (hasRequestBody) {
+                requiredBodyParameters = resolveRequiredParams(data, data.paths[path][method].requestBody.content);
               }
 
               return {
@@ -51,7 +50,7 @@ const CommandsDrawer = ({ open, toggleDrawer, handleInsertCommand }) => {
                 description,
                 hasRequestBody,
                 tags,
-                requiredBodyParameters
+                requiredBodyParameters,
               };
             });
           })

--- a/src/components/CodeEditorWindow/Menu/CommandsDrawer/CommandsDrawer.jsx
+++ b/src/components/CodeEditorWindow/Menu/CommandsDrawer/CommandsDrawer.jsx
@@ -8,6 +8,20 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { useSnackbar } from 'notistack';
 import { getSnackbarOptions } from '../../../Common/utils/snackbarOptions';
 
+const resolveRequiredParams = function(openapi, requestBodyContent){
+  const contentType = Object.keys(requestBodyContent)[0];
+  if ('$ref' in requestBodyContent[contentType].schema){
+    const refPath = requestBodyContent[contentType].schema.$ref;
+    // parse and navigate to the ref
+    const pathComponents = refPath.slice(2).split('/');
+    const schema = pathComponents.reduce((doc, pathComponent) => doc[pathComponent], openapi);
+    return schema.required;
+  }
+  else {
+    return requestBodyContent[contentType].schema.required;
+  }
+}
+
 const CommandsDrawer = ({ open, toggleDrawer, handleInsertCommand }) => {
   const [allCommands, setAllCommands] = useState([]);
   const [commands, setCommands] = useState([]);
@@ -26,6 +40,10 @@ const CommandsDrawer = ({ open, toggleDrawer, handleInsertCommand }) => {
               const description = data.paths[path][method].summary;
               const tags = data.paths[path][method].tags;
               const hasRequestBody = !!data.paths[path][method].requestBody;
+              let requiredBodyParameters = null;
+              if (hasRequestBody){
+                requiredBodyParameters = resolveRequiredParams(data, data.paths[path][method].requestBody.content)
+              }
 
               return {
                 method: method.toUpperCase(),
@@ -33,6 +51,7 @@ const CommandsDrawer = ({ open, toggleDrawer, handleInsertCommand }) => {
                 description,
                 hasRequestBody,
                 tags,
+                requiredBodyParameters
               };
             });
           })

--- a/src/components/CodeEditorWindow/Menu/CommandsDrawer/CommandsTable.jsx
+++ b/src/components/CodeEditorWindow/Menu/CommandsDrawer/CommandsTable.jsx
@@ -132,7 +132,13 @@ const CommandsTable = ({ commands, handleInsertCommand }) => {
 
   const handleClick = (command) => {
     const commandText = `${command.method} ${command.command.substring(1)}${
-      command.hasRequestBody ? ` \n{\n  ${command.requiredBodyParameters ? command.requiredBodyParameters.map(param => `"${param}": `).join(',\n  ') : ''}\n}` : ''
+      command.hasRequestBody
+        ? ` \n{\n  ${
+            command.requiredBodyParameters
+              ? command.requiredBodyParameters.map((param) => `"${param}": `).join(',\n  ')
+              : ''
+          }\n}`
+        : ''
     }`;
 
     handleInsertCommand(commandText);

--- a/src/components/CodeEditorWindow/Menu/CommandsDrawer/CommandsTable.jsx
+++ b/src/components/CodeEditorWindow/Menu/CommandsDrawer/CommandsTable.jsx
@@ -132,7 +132,7 @@ const CommandsTable = ({ commands, handleInsertCommand }) => {
 
   const handleClick = (command) => {
     const commandText = `${command.method} ${command.command.substring(1)}${
-      command.hasRequestBody ? ' \n{\n  \n}' : ''
+      command.hasRequestBody ? ` \n{\n  ${command.requiredBodyParameters ? command.requiredBodyParameters.map(param => `"${param}": `).join(',\n  ') : ''}\n}` : ''
     }`;
 
     handleInsertCommand(commandText);

--- a/src/components/CodeEditorWindow/config/CommandsDrawerUtils.js
+++ b/src/components/CodeEditorWindow/config/CommandsDrawerUtils.js
@@ -1,0 +1,12 @@
+export const resolveRequiredBodyParams = function (openapi, requestBodyContent) {
+  const contentType = Object.keys(requestBodyContent)[0];
+  if ('$ref' in requestBodyContent[contentType].schema) {
+    const refPath = requestBodyContent[contentType].schema.$ref;
+    // parse and navigate to the ref
+    const pathComponents = refPath.slice(2).split('/');
+    const schema = pathComponents.reduce((doc, pathComponent) => doc[pathComponent], openapi);
+    return schema.required;
+  } else {
+    return requestBodyContent[contentType].schema.required;
+  }
+};


### PR DESCRIPTION
Instead of returning an empty request body when inserting commands from the side panel (like it does now), we can return the required fields in the request body. This will make the commands panel truer to its use, ie. making it easier for the developer to find and write requests.

they can just insert it from the commands panel and quickly fill in the request body values, and if they want to customize it more, the [DOCS button](https://github.com/qdrant/qdrant-web-ui/pull/142) will always be there!

- **Preview**: (wait for the GIF to load)

![params](https://github.com/qdrant/qdrant-web-ui/assets/130062020/e699833d-7029-42ce-9b62-e4326c9215bb)

**Exceptions**: This won't auto-complete request bodies that can have multiple options for a single parameter [as shown below](https://qdrant.github.io/qdrant/redoc/index.html#tag/cluster/operation/update_collection_cluster) (wait for the GIF to load)

![Multiple](https://github.com/qdrant/qdrant-web-ui/assets/130062020/399ff3da-703a-4451-bd4e-9696944ca790)

This should be the preferred way as well. Inserting any one of the possible parameters might limit the user to just one operation, so it's better to encourage them to refer to the documentation.

