### PR TITLE
Add Auto-Indentation in Editor for improved Ergonomics

### DIFF
--- a/src/components/EditorCommon/config/Rules.js
+++ b/src/components/EditorCommon/config/Rules.js
@@ -32,6 +32,10 @@ export const langConfig = {
     { open: '{', close: '}' },
     { open: '[', close: ']' },
   ],
+  indentationRules: {
+    increaseIndentPattern: /{\s*$/,
+    decreaseIndentPattern: /^\s*}/,
+  },
 };
 
 export const options = {


### PR DESCRIPTION
A small but mildly annoying experience (at least for me) has been typing out the request body. Auto-indentation makes editing much faster and intuitive.

*(wait for the GIFs to load)*
**Before**:

![old_way](https://github.com/qdrant/qdrant-web-ui/assets/130062020/2f8fbc0b-5bcf-4bb5-b7f3-6beb9f025460)

**After**:

![new_way](https://github.com/qdrant/qdrant-web-ui/assets/130062020/183f4f84-adc5-45c9-abe2-57a09995f3b8)
