### PR TITLE
Fix: Multiple vectors visualization does not work if not all named vectors presented

### DIFF
--- a/src/components/FilterEditorWindow/config/RequestFromCode.js
+++ b/src/components/FilterEditorWindow/config/RequestFromCode.js
@@ -25,6 +25,7 @@ async function actionFromCode(collectionName, data, action) {
     });
     response.data.color_by = data.reqBody.color_by;
     response.data.vector_name = data.reqBody.vector_name;
+    response.data.result.points = response.data.result.points.filter((point) => Object.keys(point.vector).length > 0);
     return {
       data: response.data,
       error: null,

--- a/src/components/VisualizeChart/worker.js
+++ b/src/components/VisualizeChart/worker.js
@@ -29,7 +29,7 @@ self.onmessage = function (e) {
     if (data1.vector_name === undefined) {
       self.postMessage({
         data: [],
-        error: 'No vector name found, select a vaild vector_name',
+        error: 'No vector name found, select a valid vector_name',
       });
       return;
     } else if (data1?.result?.points[0].vector[data1?.vector_name] === undefined) {
@@ -42,7 +42,7 @@ self.onmessage = function (e) {
       if (!Array.isArray(data1?.result?.points[0].vector[data1?.vector_name])) {
         self.postMessage({
           data: [],
-          error: 'Vector visulization is not supported for sparse vector',
+          error: 'Vector visualization is not supported for sparse vector',
         });
         return;
       }
@@ -52,14 +52,14 @@ self.onmessage = function (e) {
     } else {
       self.postMessage({
         data: [],
-        error: 'Unexpected Error Occured',
+        error: 'Unexpected Error Occurred',
       });
       return;
     }
   } else {
     self.postMessage({
       data: [],
-      error: 'Unexpected Error Occured',
+      error: 'Unexpected Error Occurred',
     });
     return;
   }


### PR DESCRIPTION
Fix #159 

In `worker.js`, we were only checking the first point if the vector was present or not.

![image](https://github.com/qdrant/qdrant-web-ui/assets/130062020/c01bb1f5-e7ec-499b-8b6d-6080e5132ca2)

This would have worked if each point contained all the named vectors. But would throw an error if the first point didn't contain the queried named vector.

**The Fix**: Filter the response from `POST /collections/name/points/scroll` to strip out points with empty vectors so that only the points with the required named vector are used for further action.

