### PR TITLE
add more image extensions to PointImage test regex

### DIFF
--- a/src/components/Points/PointImage.jsx
+++ b/src/components/Points/PointImage.jsx
@@ -15,7 +15,7 @@ function PointImage({ data, sx }) {
         return false;
       }
       if (url) {
-        return /\.(jpg|jpeg|png|webp|bmp|gif|ico|svg)$/.test(url.pathname);
+        return /\.(jpg|jpeg|png|webp|gif|svg)$/.test(url.pathname);
       }
       return false;
     }

--- a/src/components/Points/PointImage.jsx
+++ b/src/components/Points/PointImage.jsx
@@ -15,7 +15,7 @@ function PointImage({ data, sx }) {
         return false;
       }
       if (url) {
-        return /\.(jpg|jpeg|png)$/.test(url.pathname);
+        return /\.(jpg|jpeg|png|webp|bmp|gif|ico|svg)$/.test(url.pathname);
       }
       return false;
     }


### PR DESCRIPTION
Just adds a few more common image extensions to the test regex in `PointImage`.

```typescript
    function isImgUrl(string) {
      let url;
      try {
        url = new URL(string);
      } catch (_) {
        return false;
      }
      if (url) {
        return /\.(jpg|jpeg|png|webp|bmp|gif|ico|svg)$/.test(url.pathname);
      }
      return false;
    }
```