### PR TITLE
Similarity search field now accepts key:value filters that contain colon ":" in the value + fix bug on "Load More" when search filter is active

### DIFF
--- a/src/components/Points/PointsTabs.jsx
+++ b/src/components/Points/PointsTabs.jsx
@@ -25,9 +25,7 @@ const PointsTabs = ({ collectionName, client }) => {
     }
     setOffset(null);
     setConditions(conditions);
-    if (conditions.length === 0) {
-      setPoints({ points: [] });
-    }
+    setPoints({ points: [] });
   };
 
   const deletePoint = (collectionName, pointIds) => {
@@ -98,15 +96,16 @@ const PointsTabs = ({ collectionName, client }) => {
             setErrorMessage(null);
           } else if (filters.length !== 0) {
             const newPoints = await qdrantClient.scroll(collectionName, {
+              offset,
               filter: {
                 must: filters,
               },
-              limit: pageSize + (offset || 0),
+              limit: pageSize,
               with_payload: true,
               with_vector: true,
             });
             setPoints({
-              points: [...(newPoints?.points || [])],
+              points: [...(points?.points || []), ...(newPoints?.points || [])],
             });
             setNextPageOffset(newPoints?.next_page_offset);
             setErrorMessage(null);

--- a/src/components/Points/SimilarSerachfield.jsx
+++ b/src/components/Points/SimilarSerachfield.jsx
@@ -11,20 +11,20 @@ function SimilarSerachfield({ conditions, onConditionChange, vectors, usingVecto
 
   const handleAddChip = (chip) => {
     setErrorMessage(null);
-    const keyValue = chip.split(':');
-    if (keyValue.length !== 2) {
+    const keyValue = chip.split(/:(.*)/);
+    if (keyValue.length < 2 || !keyValue[0].trim()) {
       setErrorMessage('Invalid format of key:value pair');
       return;
     }
     const key = keyValue[0].trim();
-    const parseToPrimitive = (keyValue) => {
+    const parseToPrimitive = (value) => {
       try {
-        return bigIntJSON.parse(keyValue[1].trim());
+        return bigIntJSON.parse(value);
       } catch (e) {
-        return keyValue[1].trim();
+        return value;
       }
     };
-    const value = parseToPrimitive(keyValue);
+    const value = parseToPrimitive(keyValue[1].trim());
     if (key === 'id') {
       if (value && (typeof value === 'number' || typeof value === 'bigint' || validateUuid(value))) {
         const id = {


### PR DESCRIPTION
Fix for allowing search filters to contain colon characters ":" which is useful for values such as Windows filepaths.

This PR fixes the following issue: [https://github.com/qdrant/qdrant-web-ui/issues/218](https://github.com/qdrant/qdrant-web-ui/issues/218).

Also, fixed a bug where a JSON error would happen when clicking "Load More" if a search filter was active.