### PR TITLE
Fix typo for advanced mode

### DIFF
--- a/src/components/Collections/SearchQuality/SearchQualityPanel.jsx
+++ b/src/components/Collections/SearchQuality/SearchQualityPanel.jsx
@@ -247,7 +247,7 @@ const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo,
               control={<Switch checked={advancedMod} onChange={() => setAdvancedMod(!advancedMod)} size="small" />}
               label={
                 <Typography component={'span'} variant={'caption'}>
-                  Advanced Mod
+                  Advanced Mode
                 </Typography>
               }
             />


### PR DESCRIPTION
I believe this is a typo:

![image](https://github.com/user-attachments/assets/eb25a7c8-1fa6-4df5-95a4-1f3a0f213f3b)
