### PR TITLE
docs(search-quality): add button and explanation for the Search Quality tab

### DIFF
--- a/src/components/Collections/SearchQuality/SearchQuality.jsx
+++ b/src/components/Collections/SearchQuality/SearchQuality.jsx
@@ -10,6 +10,24 @@ import { bigIntJSON } from '../../../common/bigIntJSON';
 import EditorCommon from '../../EditorCommon';
 import _ from 'lodash';
 
+const explainLog = `Example Output: [18/10/2024, 01:51:38] Point ID 1(1/100) precision@10: 0.8 (search time exact: 30ms, regular: 5ms)
+
+Explanation:
+This output compares the performance of an exact search (full kNN) versus an approximate search using ANN (Approximate Nearest Neighbor). 
+
+- precision@10: 0.8: Out of the top 10 results returned by the exact search, 8 were also found in the ANN search.
+- Search Time: The exact search took 30ms, whereas the ANN search was much faster, taking only 5ms, but with a small loss in accuracy.
+
+Tuning the HNSW Algorithm (Advanced mode):
+- "hnsw_ef" parameter: Controls how many neighbors to consider during a search. Increasing "hnsw_ef" improves precision but slows down the search.
+  
+Practical Use:
+- The ANN search (with HNSW) is significantly faster (5ms compared to 30ms) but slightly less accurate (precision@10: 0.8). You can adjust parameters like "hnsw_ef" in advanced mode to find the right balance between speed and accuracy.
+
+Additional Tuning Parameters (need to be set during collection configuration):
+1. "m" Parameter : Defines the number of edges per node in the graph. A higher "m" value improves accuracy but uses more memory.
+2. "ef_construct" Parameter: Sets the number of neighbors to consider during index creation. A higher value increases precision but requires more time during indexing.`;
+
 const SearchQuality = ({ collectionName }) => {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
   const { client } = useClient();
@@ -25,7 +43,7 @@ const SearchQuality = ({ collectionName }) => {
   };
 
   const clearLogs = () => {
-    setLog('');
+    setLog(' ');
   };
 
   useEffect(() => {
@@ -62,7 +80,7 @@ const SearchQuality = ({ collectionName }) => {
 
       <Card varian="dual" sx={{ mt: 5 }}>
         <CardHeader
-          title={'Report'}
+          title={log ? 'Report' : 'What is Search Quality?'}
           variant="heading"
           sx={{
             flexGrow: 1,
@@ -71,8 +89,10 @@ const SearchQuality = ({ collectionName }) => {
         />
         <Box sx={{ pt: 2, pb: 1, pr: 1 }}>
           <EditorCommon
+            language={'custom-language'}
             theme={'custom-language-theme'}
-            value={log}
+            value={log || explainLog}
+            customHeight={'calc(100vh - 660px)'}
             options={{
               scrollBeyondLastLine: false,
               fontSize: 12,

--- a/src/components/Collections/SearchQuality/SearchQualityPanel.jsx
+++ b/src/components/Collections/SearchQuality/SearchQualityPanel.jsx
@@ -9,11 +9,13 @@ import {
   TableHead,
   TableRow,
   Tooltip,
-  IconButton,
+  Button,
   FormControlLabel,
   Switch,
   CardContent,
   LinearProgress,
+  Box,
+  IconButton,
 } from '@mui/material';
 import { CopyButton } from '../../Common/CopyButton';
 import { bigIntJSON } from '../../../common/bigIntJSON';
@@ -44,21 +46,33 @@ const VectorTableRow = ({ vectorObj, name, onCheckIndexQuality, precision, isInP
       <TableCell>
         {isInProgress && <LinearProgress />}
         {!isInProgress && (
-          <>
-            <Typography variant="subtitle1" component={'span'} color="text.secondary">
-              {precision ? `${precision * 100}%` : '—'}
+          <Box display="flex" alignItems="center">
+            <Typography variant="subtitle1" component={'span'} color="text.secondary" >
+              {precision ? `${precision * 100}%` : null}
             </Typography>
             <Tooltip title="Check index quality">
-              <IconButton
-                aria-label="Check index quality"
-                data-testid="index-quality-check-button"
-                onClick={onCheckIndexQuality}
-                sx={{ p: 0, ml: 1 }}
-              >
-                <PublishedWithChanges color={'primary'} />
-              </IconButton>
+              {precision ? (
+                <IconButton
+                  aria-label="Check index quality"
+                  data-testid="index-quality-check-button"
+                  onClick={onCheckIndexQuality}
+                  sx={{ p: 0, ml: 3 }}
+                >
+                  <PublishedWithChanges color={'primary'} />
+                </IconButton>
+              ) : (
+                <Button
+                  variant="outlined"
+                  color="primary"
+                  startIcon={<PublishedWithChanges />}
+                  onClick={onCheckIndexQuality}
+                  data-testid="index-quality-check-button"
+                >
+                  Check Quality
+                </Button>
+              )}
             </Tooltip>
-          </>
+          </Box>
         )}
       </TableCell>
     </TableRow>
@@ -240,8 +254,10 @@ const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo,
     <Card variant="dual" data-testid="vectors-info" {...other}>
       <CardHeader
         title={
-          <>
-            Search Quality
+          <Box display="flex" alignItems="center">
+            <Typography variant="h6" component="div">
+              Search Quality
+            </Typography>
             <FormControlLabel
               sx={{ ml: 2 }}
               control={<Switch checked={advancedMod} onChange={() => setAdvancedMod(!advancedMod)} size="small" />}
@@ -251,17 +267,13 @@ const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo,
                 </Typography>
               }
             />
-          </>
+          </Box>
         }
         variant="heading"
         sx={{
           flexGrow: 1,
         }}
-        action={
-          <>
-            <CopyButton text={advancedMod ? code : bigIntJSON.stringify(vectors)} />
-          </>
-        }
+        action={<CopyButton text={advancedMod ? code : bigIntJSON.stringify(vectors)} />}
       />
       {!advancedMod && (
         <Table>


### PR DESCRIPTION
<img width="1710" alt="Screenshot 2024-10-18 at 2 14 13 AM" src="https://github.com/user-attachments/assets/6335cf75-e0f5-458e-b8ad-f740431af65b">


* Added a explanation log for search quality output, including information on precision and tuning parameters. 
* Improved the display of index quality checks by using a button when precision is not available, and adjusted the layout for better alignment. 