### PR TITLE
fix[VisualizeChart]: define color for null and undefined in VisualizeChart

### DIFF
--- a/src/components/VisualizeChart/renderBy.js
+++ b/src/components/VisualizeChart/renderBy.js
@@ -75,9 +75,6 @@ export function generateColorBy(points, colorBy = null) {
 
     return points.map((point) => {
       const payloadValue = getNestedValue(point.payload, colorBy.payload);
-      if (payloadValue === undefined || payloadValue === null) {
-        return BACKGROUND_COLOR;
-      }
       return colorByPayload(payloadValue, valuesToColor);
     });
   }


### PR DESCRIPTION
<img width="1710" alt="Screenshot 2024-12-03 at 9 10 48 PM" src="https://github.com/user-attachments/assets/408a1e2a-62c9-41af-ba41-1eb269fcb901">
