### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    open-pull-requests-limit: 0 # security updates only
+    schedule:
+      interval: daily
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily


### PR DESCRIPTION
For JS, only PRs for security updates will be created. Other updates should be done manually.
