### PR TITLE
Show similarity scores for points when available.

### DIFF
--- a/src/components/Points/PointCard.jsx
+++ b/src/components/Points/PointCard.jsx
@@ -65,6 +65,7 @@ const PointCard = (props) => {
         )}
         <CardHeader
           title={'Point ' + point.id}
+          subheader={point.score && `Score: ${point.score}`}
           action={
             <>
               {Object.keys(point.payload).length === 0 && (

--- a/src/components/Points/PointsTabs.jsx
+++ b/src/components/Points/PointsTabs.jsx
@@ -170,6 +170,7 @@ const PointsTabs = ({ collectionName, client }) => {
           <Grid xs={12} item key={point.id}>
             <PointCard
               point={point}
+              score={point.score}
               onConditionChange={onConditionChange}
               conditions={conditions}
               collectionName={collectionName}


### PR DESCRIPTION
# Feature

Show the similarity score in the Point Card whenever available.

## Preview

![image](https://github.com/user-attachments/assets/9d5c6925-7330-40e1-af76-8b23154bff17)


Apologies if I'm missing something but I noticed the results of the similarity search didn't show a score in the point card. 

I picture this to be useful for preliminary data exploration when trying to come up with a meaningful threshold for a use case.