### PR TITLE
Set UMAP as default algorithm for visualization

### DIFF
--- a/src/components/VisualizeChart/worker.js
+++ b/src/components/VisualizeChart/worker.js
@@ -3,7 +3,7 @@ import * as druid from '@saehrimnir/druidjs';
 import get from 'lodash/get';
 
 const MESSAGE_INTERVAL = 200;
-const DEFAULT_ALGORITHM = "UMAP";
+const DEFAULT_ALGORITHM = 'UMAP';
 
 function getVectorType(vector) {
   if (Array.isArray(vector)) {


### PR DESCRIPTION
`UMAP` is an algorithm that builds on the concepts of `t-SNE` (graph-based approach) but performs much faster, with good mathematical foundation. I think we should use it as the default algorithm.