### PR TITLE
Fix scroll for code editor in Visualize

### DIFF
--- a/src/components/EditorCommon/index.jsx
+++ b/src/components/EditorCommon/index.jsx
@@ -59,7 +59,7 @@ const EditorCommon = ({ beforeMount, customHeight, ...props }) => {
   }, [height, editorWrapper]);
 
   return (
-    <div className={theme.palette.mode} ref={editorWrapper}>
+    <div className={theme.palette.mode} ref={editorWrapper} style={{ height: '100%' }}>
       <Editor
         theme={props.theme ?? 'custom-language-theme'} // todo: move to config
         height={editorHeight}

--- a/src/pages/Visualize.jsx
+++ b/src/pages/Visualize.jsx
@@ -215,6 +215,7 @@ function Visualize() {
                       onChange={setCode}
                       onChangeResult={onEditorCodeRun}
                       customRequestSchema={filterRequestSchema}
+                      customHeight="100%"
                     />
                   </Panel>
                   <PanelResizeHandle


### PR DESCRIPTION
Without this, the scrollbar didn't appear on larger screens, so the only way to see the rest of the editor was changing the panel size.

This PR fixes it for the Visualize section, which was the only place affected by vertical `Panel`s

https://github.com/user-attachments/assets/88dfb2a3-dc95-4fdf-877c-d167a8143a6d

