### PR TITLE
SearchQualityPanel: Pass actual limit to initial scroll call

### DIFF
--- a/src/components/Collections/SearchQuality/SearchQualityPanel.jsx
+++ b/src/components/Collections/SearchQuality/SearchQualityPanel.jsx
@@ -177,7 +177,7 @@ const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo,
       const scrollResult = await client.scroll(collectionName, {
         with_payload: false,
         with_vector: false,
-        limit: 100,
+        limit,
       });
 
       // todo: if exceeded timeout


### PR DESCRIPTION
I ran into this bug when trying to run it with just 10 points as it takes 3min per point with exact search. It still requested 100 points and I thus never really finished the entire run.