### PR TITLE
Improve Quickstart for Cloud users

### DIFF
--- a/src/components/InteractiveTutorial/MdxPages/FilteringFullText.mdx
+++ b/src/components/InteractiveTutorial/MdxPages/FilteringFullText.mdx
@@ -100,6 +100,8 @@ POST /collections/star_charts/points/scroll
 
 You’ll notice this filter works, but if you change the phrase slightly, it won’t return results, since substring matching in unindexed text isn’t flexible enough for variations.
 
+**Note**: If your cluster is running on Qdrant Cloud, this query fails. On Qdrant Cloud, collections are configured to run in strict mode by default, which prevents querying unindexed fields. You'll learn how to index a field for text filtering next.
+
 ### Step 4: Index the description field
 
 To make filtering more powerful and flexible, we’ll index the `description` field. This will tokenize the text, allowing for more complex queries such as filtering for phrases like "cave colonies." We use a `word` tokenizer, and only tokens that are between 5 and 20 characters will be indexed.
@@ -121,7 +123,7 @@ PUT /collections/star_charts/index
 ### Step 5: Try the filter again
 
 After indexing, you can now run the filter again, but this time not searching for a phrase. 
-Now you will filter for all tokens "cave" AND "colonies" from the descriptions. 
+Now you will filter for all tokens "caves" AND "colonies" from the descriptions. 
 
 ```json withRunButton="true"
 POST /collections/star_charts/points/scroll
@@ -131,7 +133,7 @@ POST /collections/star_charts/points/scroll
       {
         "key": "description",
         "match": {
-          "text": "cave colonies"
+          "text": "caves colonies"
         }
       }
     ]
@@ -142,4 +144,4 @@ POST /collections/star_charts/points/scroll
 ```
 ## Summary
 
-Phrase search requires tokens to come in and exact sequence, and by indexing all words we are ignoring the sequence completely and filtering for relevant keywords.
+Full text filtering on an unindexed field performs a substring match by default, or results in an error on collections running in strict mode (the default on Qdrant Cloud). It's a best practice to index the field first. This enables more advanced full text queries, such as queries that ignore the word sequence completely.

--- a/src/components/InteractiveTutorial/MdxPages/LoadContent.mdx
+++ b/src/components/InteractiveTutorial/MdxPages/LoadContent.mdx
@@ -30,5 +30,5 @@ POST /collections/midjourney/points/count
 
 The collection should contain 5,417 data points. 
 
-### Step 4: Open the collection UI
+### Step 3: Open the collection UI
 You can also [inspect your collection](/dashboard#/collections/midjourney/) to review the uploaded data.

--- a/src/components/InteractiveTutorial/MdxPages/Multitenancy.mdx
+++ b/src/components/InteractiveTutorial/MdxPages/Multitenancy.mdx
@@ -166,15 +166,15 @@ PUT /collections/central_library/points
 
 ## Step 6: Group query results
 
-You can group query results by specific fields, such as `station`, to get an overview of each tenant's data. This query groups results by `station` and limits the number of groups and the number of points per group.
+You can group query results by specific fields, such as `group_id`, to get an overview of each tenant's data. This query groups results by `group_id` and limits the number of groups and the number of points per group.
 
-Run the following request to group the results by `station`:
+Run the following request to group the results by `group_id`:
 
 ```json withRunButton=true
 POST /collections/central_library/points/query/groups
 {
     "query": [0.01, 0.45, 0.6, 0.88],
-    "group_by": "station",  
+    "group_by": "group_id",  
     "limit": 5,  
     "group_size": 5,
     "with_payload": true  


### PR DESCRIPTION
This PR improves the quickstart tutorial for users on Qdrant Cloud. On Qdrant Cloud, collections are configured to run in strict mode by default. This causes two steps in the quickstart to result in an error when operating on unindexed fields:

- substring match on the `description` field in the full-text filtering tutorial.
- `group_by` on the `station` field in the multitenancy tutorial.

For the full-text filtering tutorial, I've added a note that explains why you see an error on Qdrant Cloud. For the multitenancy tutorial, I've switched the example to do a `group_by` on the `group_id` field instead.

While I was at it, I fixed a couple of typos (`cave` should be `caves` in the full-text tutorial and an incorrect step number in the snapshot importing tutorial).