### PR TITLE
Update dataset snapshots to support Qdrant 1.16.0 and up

### DIFF
--- a/src/pages/Datasets.jsx
+++ b/src/pages/Datasets.jsx
@@ -25,7 +25,7 @@ function Datasets() {
     const fetchData = async () => {
       setIsLoading(true);
       try {
-        const response = await fetch('https://snapshots.qdrant.io/manifest.json');
+        const response = await fetch('https://snapshots.qdrant.io/manifest-v1.16.0.json');
         const responseJson = await response.json();
         const datasets = responseJson
           .filter((dataset) => {


### PR DESCRIPTION
Related to <https://github.com/qdrant/qdrant/pull/7552>

This updates the snapshot manifest to use snapshots that are compatible with Qdrant 1.16.0 and up.

With the removal of RocksDB support in <https://github.com/qdrant/qdrant/pull/7552>, all snapshots must bee updated to switch from RocksDB to Gridstore.