### PR TITLE
Add inline field descriptions to Collection Info panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3840,14 +3840,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "license": "MIT",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -8528,8 +8527,12 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -30,9 +30,10 @@
           {
             "name": "timeout",
             "in": "query",
-            "description": "Wait for operation commit timeout in seconds. \nIf timeout is reached - request will return with service error.\n",
+            "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],
@@ -68,7 +69,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -87,6 +88,82 @@
                     },
                     "result": {
                       "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Distributed"
+        ],
+        "summary": "List shard keys",
+        "operationId": "list_shard_keys",
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection to list shard keys for",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "usage": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/Usage"
+                        },
+                        {
+                          "nullable": true
+                        }
+                      ]
+                    },
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request",
+                      "example": 0.002
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/ShardKeysResponse"
                     }
                   }
                 }
@@ -126,9 +203,10 @@
           {
             "name": "timeout",
             "in": "query",
-            "description": "Wait for operation commit timeout in seconds. \nIf timeout is reached - request will return with service error.\n",
+            "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],
@@ -164,7 +242,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -244,6 +322,26 @@
               "type": "integer",
               "minimum": 0
             }
+          },
+          {
+            "name": "per_collection",
+            "in": "query",
+            "description": "If true, include per-collection request statistics in the response",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for this request",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 60
+            }
           }
         ],
         "responses": {
@@ -278,7 +376,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -323,6 +421,26 @@
             "schema": {
               "type": "boolean"
             }
+          },
+          {
+            "name": "per_collection",
+            "in": "query",
+            "description": "If true, include per-collection request metrics with a collection label instead of global request metrics",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for this request",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 60
+            }
           }
         ],
         "responses": {
@@ -339,150 +457,6 @@
           },
           "4XX": {
             "description": "error"
-          }
-        }
-      }
-    },
-    "/locks": {
-      "post": {
-        "summary": "Set lock options",
-        "description": "Set lock options. If write is locked, all write operations and collection creation are forbidden. Returns previous lock options",
-        "operationId": "post_locks",
-        "tags": [
-          "Service"
-        ],
-        "requestBody": {
-          "description": "Lock options and optional error message",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LocksOption"
-              }
-            }
-          }
-        },
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "usage": {
-                      "default": null,
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/HardwareUsage"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
-                    },
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request",
-                      "example": 0.002
-                    },
-                    "status": {
-                      "type": "string",
-                      "example": "ok"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/LocksOption"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "summary": "Get lock options",
-        "description": "Get lock options. If write is locked, all write operations and collection creation are forbidden",
-        "operationId": "get_locks",
-        "tags": [
-          "Service"
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "usage": {
-                      "default": null,
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/HardwareUsage"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
-                    },
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request",
-                      "example": 0.002
-                    },
-                    "status": {
-                      "type": "string",
-                      "example": "ok"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/LocksOption"
-                    }
-                  }
-                }
-              }
-            }
           }
         }
       }
@@ -597,18 +571,61 @@
           "Beta"
         ],
         "responses": {
-          "200": {
-            "description": "Successful response",
+          "default": {
+            "description": "error",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "boolean"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
           },
           "4XX": {
-            "description": "error"
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "usage": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/Usage"
+                        },
+                        {
+                          "nullable": true
+                        }
+                      ]
+                    },
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request",
+                      "example": 0.002
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "result": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -653,7 +670,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -672,6 +689,96 @@
                     },
                     "result": {
                       "$ref": "#/components/schemas/ClusterStatus"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cluster/telemetry": {
+      "get": {
+        "tags": [
+          "Distributed"
+        ],
+        "summary": "Collect cluster telemetry data",
+        "description": "Get telemetry data, from the point of view of the cluster. This includes peers info, collections info, shard transfers, and resharding status",
+        "operationId": "cluster_telemetry",
+        "parameters": [
+          {
+            "name": "details_level",
+            "in": "query",
+            "description": "The level of detail to include in the response",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for this request",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 60
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "usage": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/Usage"
+                        },
+                        {
+                          "nullable": true
+                        }
+                      ]
+                    },
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request",
+                      "example": 0.002
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/DistributedTelemetryData"
                     }
                   }
                 }
@@ -720,7 +827,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -767,6 +874,15 @@
             }
           },
           {
+            "name": "timeout",
+            "in": "query",
+            "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
             "name": "force",
             "in": "query",
             "description": "If true - removes peer even if it has shards/replicas on it.",
@@ -808,7 +924,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -876,7 +992,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -955,7 +1071,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -1012,9 +1128,10 @@
           {
             "name": "timeout",
             "in": "query",
-            "description": "Wait for operation commit timeout in seconds. \nIf timeout is reached - request will return with service error.\n",
+            "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],
@@ -1050,7 +1167,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -1107,9 +1224,10 @@
           {
             "name": "timeout",
             "in": "query",
-            "description": "Wait for operation commit timeout in seconds. \nIf timeout is reached - request will return with service error.\n",
+            "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],
@@ -1145,7 +1263,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -1192,9 +1310,10 @@
           {
             "name": "timeout",
             "in": "query",
-            "description": "Wait for operation commit timeout in seconds. \nIf timeout is reached - request will return with service error.\n",
+            "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],
@@ -1230,7 +1349,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -1279,9 +1398,10 @@
           {
             "name": "timeout",
             "in": "query",
-            "description": "Wait for operation commit timeout in seconds. \nIf timeout is reached - request will return with service error.\n",
+            "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],
@@ -1317,7 +1437,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -1380,6 +1500,16 @@
             "schema": {
               "$ref": "#/components/schemas/WriteOrdering"
             }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for the operation",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         ],
         "requestBody": {
@@ -1424,7 +1554,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -1503,7 +1633,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -1575,6 +1705,16 @@
             "schema": {
               "$ref": "#/components/schemas/WriteOrdering"
             }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for the operation",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         ],
         "responses": {
@@ -1609,7 +1749,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -1628,6 +1768,246 @@
                     },
                     "result": {
                       "$ref": "#/components/schemas/UpdateResult"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/vectors/{vector_name}": {
+      "put": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Create named vector",
+        "description": "Create a new named vector on an existing collection",
+        "operationId": "create_vector_name",
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "vector_name",
+            "in": "path",
+            "description": "Name of the vector to create",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "description": "If true, wait for changes to actually happen",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "define ordering guarantees for the operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/WriteOrdering"
+            }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for the operation",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Vector configuration - dense or sparse",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VectorNameConfig"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "usage": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/Usage"
+                        },
+                        {
+                          "nullable": true
+                        }
+                      ]
+                    },
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request",
+                      "example": 0.002
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "result": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Delete named vector",
+        "description": "Delete a named vector from a collection",
+        "operationId": "delete_vector_name",
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "vector_name",
+            "in": "path",
+            "description": "Name of the vector to delete",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "description": "If true, wait for changes to actually happen",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "define ordering guarantees for the operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/WriteOrdering"
+            }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for the operation",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "usage": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/Usage"
+                        },
+                        {
+                          "nullable": true
+                        }
+                      ]
+                    },
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request",
+                      "example": 0.002
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "result": {
+                      "type": "boolean"
                     }
                   }
                 }
@@ -1688,7 +2068,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -1744,9 +2124,10 @@
           {
             "name": "timeout",
             "in": "query",
-            "description": "Wait for operation commit timeout in seconds. \nIf timeout is reached - request will return with service error.\n",
+            "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],
@@ -1782,7 +2163,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -1801,6 +2182,105 @@
                     },
                     "result": {
                       "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/optimizations": {
+      "get": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Get optimization progress",
+        "description": "Get progress of ongoing and completed optimizations for a collection",
+        "operationId": "get_optimizations",
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "with",
+            "in": "query",
+            "description": "Comma-separated list of optional fields to include in the response.\nPossible values: queued, completed, idle_segments.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "completed_limit",
+            "in": "query",
+            "description": "Maximum number of completed optimizations to return.\nIgnored if `completed` is not in the `with` parameter.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 16
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "usage": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/Usage"
+                        },
+                        {
+                          "nullable": true
+                        }
+                      ]
+                    },
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request",
+                      "example": 0.002
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/OptimizationsResponse"
                     }
                   }
                 }
@@ -1861,7 +2341,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -1929,7 +2409,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -2246,7 +2726,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -2579,7 +3059,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -2807,6 +3287,69 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Snapshot file",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/shards/{shard_id}/snapshot": {
+      "get": {
+        "tags": [
+          "Snapshots"
+        ],
+        "summary": "Download shard snapshot",
+        "description": "Stream the current state of a shard as a snapshot file",
+        "operationId": "stream_shard_snapshot",
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "shard_id",
+            "in": "path",
+            "description": "Id of the shard",
+            "required": true,
+            "schema": {
+              "type": "integer"
             }
           }
         ],
@@ -3161,7 +3704,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -3550,7 +4093,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -3658,7 +4201,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -3732,6 +4275,16 @@
             "schema": {
               "$ref": "#/components/schemas/WriteOrdering"
             }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for the operation",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         ],
         "responses": {
@@ -3766,7 +4319,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -3839,6 +4392,16 @@
             "schema": {
               "$ref": "#/components/schemas/WriteOrdering"
             }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for the operation",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         ],
         "responses": {
@@ -3873,7 +4436,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -3946,6 +4509,16 @@
             "schema": {
               "$ref": "#/components/schemas/WriteOrdering"
             }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for the operation",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         ],
         "responses": {
@@ -3980,7 +4553,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -4053,6 +4626,16 @@
             "schema": {
               "$ref": "#/components/schemas/WriteOrdering"
             }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for the operation",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         ],
         "responses": {
@@ -4087,7 +4670,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -4160,6 +4743,16 @@
             "schema": {
               "$ref": "#/components/schemas/WriteOrdering"
             }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for the operation",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         ],
         "responses": {
@@ -4194,7 +4787,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -4265,6 +4858,16 @@
             "schema": {
               "$ref": "#/components/schemas/WriteOrdering"
             }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for the operation",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         ],
         "responses": {
@@ -4299,7 +4902,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -4372,6 +4975,16 @@
             "schema": {
               "$ref": "#/components/schemas/WriteOrdering"
             }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for the operation",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         ],
         "responses": {
@@ -4406,7 +5019,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -4479,6 +5092,16 @@
             "schema": {
               "$ref": "#/components/schemas/WriteOrdering"
             }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for the operation",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         ],
         "responses": {
@@ -4513,7 +5136,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -4586,6 +5209,16 @@
             "schema": {
               "$ref": "#/components/schemas/WriteOrdering"
             }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout for the operation",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         ],
         "responses": {
@@ -4620,7 +5253,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -4731,7 +5364,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -4761,6 +5394,7 @@
     },
     "/collections/{collection_name}/points/search": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
@@ -4839,7 +5473,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -4872,6 +5506,7 @@
     },
     "/collections/{collection_name}/points/search/batch": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
@@ -4950,7 +5585,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -4986,6 +5621,7 @@
     },
     "/collections/{collection_name}/points/search/groups": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
@@ -5064,7 +5700,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -5094,6 +5730,7 @@
     },
     "/collections/{collection_name}/points/recommend": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
@@ -5172,7 +5809,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -5205,6 +5842,7 @@
     },
     "/collections/{collection_name}/points/recommend/batch": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
@@ -5283,7 +5921,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -5319,6 +5957,7 @@
     },
     "/collections/{collection_name}/points/recommend/groups": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
@@ -5397,7 +6036,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -5427,11 +6066,12 @@
     },
     "/collections/{collection_name}/points/discover": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
         "summary": "Discover points",
-        "description": "Use context and a target to find the most similar points to the target, constrained by the context.\nWhen using only the context (without a target), a special search - called context search - is performed where pairs of points are used to generate a loss that guides the search towards the zone where most positive examples overlap. This means that the score minimizes the scenario of finding a point closer to a negative than to a positive part of a pair.\nSince the score of a context relates to loss, the maximum score a point can get is 0.0, and it becomes normal that many points can have a score of 0.0.\nWhen using target (with or without context), the score behaves a little different: The  integer part of the score represents the rank with respect to the context, while the decimal part of the score relates to the distance to the target. The context part of the score for  each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair,  and -1 otherwise.\n",
+        "description": "Use context and a target to find the most similar points to the target, constrained by the context.\nWhen using only the context (without a target), a special search - called context search - is performed where pairs of points are used to generate a loss that guides the search towards the zone where most positive examples overlap. This means that the score minimizes the scenario of finding a point closer to a negative than to a positive part of a pair.\nSince the score of a context relates to loss, the maximum score a point can get is 0.0, and it becomes normal that many points can have a score of 0.0.\nWhen using target (with or without context), the score behaves a little different: The integer part of the score represents the rank with respect to the context, while the decimal part of the score relates to the distance to the target. The context part of the score for each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair, and -1 otherwise.\n",
         "operationId": "discover_points",
         "requestBody": {
           "description": "Request points based on {positive, negative} pairs of examples, and/or a target",
@@ -5505,7 +6145,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -5538,6 +6178,7 @@
     },
     "/collections/{collection_name}/points/discover/batch": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
@@ -5616,7 +6257,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -5679,6 +6320,15 @@
             }
           },
           {
+            "name": "consistency",
+            "in": "query",
+            "description": "Define read consistency guarantees for the operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ReadConsistency"
+            }
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "If set, overrides global timeout for this request. Unit is seconds.",
@@ -5721,7 +6371,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -5778,6 +6428,15 @@
             }
           },
           {
+            "name": "consistency",
+            "in": "query",
+            "description": "Define read consistency guarantees for the operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ReadConsistency"
+            }
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "If set, overrides global timeout for this request. Unit is seconds.",
@@ -5785,15 +6444,6 @@
             "schema": {
               "type": "integer",
               "minimum": 1
-            }
-          },
-          {
-            "name": "consistency",
-            "in": "query",
-            "description": "Define read consistency guarantees for the operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/ReadConsistency"
             }
           }
         ],
@@ -5829,7 +6479,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -5937,7 +6587,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -6045,7 +6695,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -6156,7 +6806,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -6264,7 +6914,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -6372,7 +7022,7 @@
                       "default": null,
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/HardwareUsage"
+                          "$ref": "#/components/schemas/Usage"
                         },
                         {
                           "nullable": true
@@ -6413,7 +7063,7 @@
   ],
   "info": {
     "title": "Qdrant API",
-    "description": "API description for Qdrant vector search engine.\n\nThis document describes CRUD and search operations on collections of points (vectors with payload).\n\nQdrant supports any combinations of `should`, `min_should`, `must` and `must_not` conditions, which makes it possible to use in applications when object could not be described solely by vector. It could be location features, availability flags, and other custom properties businesses should take into account.\n## Examples\nThis examples cover the most basic use-cases - collection creation and basic vector search.\n### Create collection\nFirst - let's create a collection with dot-production metric.\n```\ncurl -X PUT 'http://localhost:6333/collections/test_collection' \\\n  -H 'Content-Type: application/json' \\\n  --data-raw '{\n    \"vectors\": {\n      \"size\": 4,\n      \"distance\": \"Dot\"\n    }\n  }'\n\n```\nExpected response:\n```\n{\n    \"result\": true,\n    \"status\": \"ok\",\n    \"time\": 0.031095451\n}\n```\nWe can ensure that collection was created:\n```\ncurl 'http://localhost:6333/collections/test_collection'\n```\nExpected response:\n```\n{\n  \"result\": {\n    \"status\": \"green\",\n    \"vectors_count\": 0,\n    \"segments_count\": 5,\n    \"disk_data_size\": 0,\n    \"ram_data_size\": 0,\n    \"config\": {\n      \"params\": {\n        \"vectors\": {\n          \"size\": 4,\n          \"distance\": \"Dot\"\n        }\n      },\n      \"hnsw_config\": {\n        \"m\": 16,\n        \"ef_construct\": 100,\n        \"full_scan_threshold\": 10000\n      },\n      \"optimizer_config\": {\n        \"deleted_threshold\": 0.2,\n        \"vacuum_min_vector_number\": 1000,\n        \"default_segment_number\": 2,\n        \"max_segment_size\": null,\n        \"memmap_threshold\": null,\n        \"indexing_threshold\": 20000,\n        \"flush_interval_sec\": 5,\n        \"max_optimization_threads\": null\n      },\n      \"wal_config\": {\n        \"wal_capacity_mb\": 32,\n        \"wal_segments_ahead\": 0\n      }\n    }\n  },\n  \"status\": \"ok\",\n  \"time\": 2.1199e-05\n}\n```\n\n### Add points\nLet's now add vectors with some payload:\n```\ncurl -L -X PUT 'http://localhost:6333/collections/test_collection/points?wait=true' \\ -H 'Content-Type: application/json' \\ --data-raw '{\n  \"points\": [\n    {\"id\": 1, \"vector\": [0.05, 0.61, 0.76, 0.74], \"payload\": {\"city\": \"Berlin\"}},\n    {\"id\": 2, \"vector\": [0.19, 0.81, 0.75, 0.11], \"payload\": {\"city\": [\"Berlin\", \"London\"] }},\n    {\"id\": 3, \"vector\": [0.36, 0.55, 0.47, 0.94], \"payload\": {\"city\": [\"Berlin\", \"Moscow\"] }},\n    {\"id\": 4, \"vector\": [0.18, 0.01, 0.85, 0.80], \"payload\": {\"city\": [\"London\", \"Moscow\"] }},\n    {\"id\": 5, \"vector\": [0.24, 0.18, 0.22, 0.44], \"payload\": {\"count\": [0]}},\n    {\"id\": 6, \"vector\": [0.35, 0.08, 0.11, 0.44]}\n  ]\n}'\n```\nExpected response:\n```\n{\n    \"result\": {\n        \"operation_id\": 0,\n        \"status\": \"completed\"\n    },\n    \"status\": \"ok\",\n    \"time\": 0.000206061\n}\n```\n### Search with filtering\nLet's start with a basic request:\n```\ncurl -L -X POST 'http://localhost:6333/collections/test_collection/points/search' \\ -H 'Content-Type: application/json' \\ --data-raw '{\n    \"vector\": [0.2,0.1,0.9,0.7],\n    \"top\": 3\n}'\n```\nExpected response:\n```\n{\n    \"result\": [\n        { \"id\": 4, \"score\": 1.362, \"payload\": null, \"version\": 0 },\n        { \"id\": 1, \"score\": 1.273, \"payload\": null, \"version\": 0 },\n        { \"id\": 3, \"score\": 1.208, \"payload\": null, \"version\": 0 }\n    ],\n    \"status\": \"ok\",\n    \"time\": 0.000055785\n}\n```\nBut result is different if we add a filter:\n```\ncurl -L -X POST 'http://localhost:6333/collections/test_collection/points/search' \\ -H 'Content-Type: application/json' \\ --data-raw '{\n    \"filter\": {\n        \"should\": [\n            {\n                \"key\": \"city\",\n                \"match\": {\n                    \"value\": \"London\"\n                }\n            }\n        ]\n    },\n    \"vector\": [0.2, 0.1, 0.9, 0.7],\n    \"top\": 3\n}'\n```\nExpected response:\n```\n{\n    \"result\": [\n        { \"id\": 4, \"score\": 1.362, \"payload\": null, \"version\": 0 },\n        { \"id\": 2, \"score\": 0.871, \"payload\": null, \"version\": 0 }\n    ],\n    \"status\": \"ok\",\n    \"time\": 0.000093972\n}\n```\n",
+    "description": "API description for Qdrant vector search engine.\n\nThis document describes CRUD and search operations on collections of points (vectors with payload).\n\nQdrant supports any combinations of `should`, `min_should`, `must` and `must_not` conditions, which makes it possible to use in applications when object could not be described solely by vector. It could be location features, availability flags, and other custom properties businesses should take into account.\n## Examples\nThis examples cover the most basic use-cases - collection creation and basic vector search.\n### Create collection\nFirst - let's create a collection with dot-production metric.\n```\ncurl -X PUT 'http://localhost:6333/collections/test_collection' \\\n  -H 'Content-Type: application/json' \\\n  --data-raw '{\n    \"vectors\": {\n      \"size\": 4,\n      \"distance\": \"Dot\"\n    }\n  }'\n\n```\nExpected response:\n```\n{\n    \"result\": true,\n    \"status\": \"ok\",\n    \"time\": 0.031095451\n}\n```\nWe can ensure that collection was created:\n```\ncurl 'http://localhost:6333/collections/test_collection'\n```\nExpected response:\n```\n{\n  \"result\": {\n    \"status\": \"green\",\n    \"segments_count\": 5,\n    \"disk_data_size\": 0,\n    \"ram_data_size\": 0,\n    \"config\": {\n      \"params\": {\n        \"vectors\": {\n          \"size\": 4,\n          \"distance\": \"Dot\"\n        }\n      },\n      \"hnsw_config\": {\n        \"m\": 16,\n        \"ef_construct\": 100,\n        \"full_scan_threshold\": 10000\n      },\n      \"optimizer_config\": {\n        \"deleted_threshold\": 0.2,\n        \"vacuum_min_vector_number\": 1000,\n        \"default_segment_number\": 2,\n        \"max_segment_size\": null,\n        \"memmap_threshold\": null,\n        \"indexing_threshold\": 20000,\n        \"flush_interval_sec\": 5,\n        \"max_optimization_threads\": null\n      },\n      \"wal_config\": {\n        \"wal_capacity_mb\": 32,\n        \"wal_segments_ahead\": 0\n      }\n    }\n  },\n  \"status\": \"ok\",\n  \"time\": 2.1199e-05\n}\n```\n\n### Add points\nLet's now add vectors with some payload:\n```\ncurl -L -X PUT 'http://localhost:6333/collections/test_collection/points?wait=true' \\ -H 'Content-Type: application/json' \\ --data-raw '{\n  \"points\": [\n    {\"id\": 1, \"vector\": [0.05, 0.61, 0.76, 0.74], \"payload\": {\"city\": \"Berlin\"}},\n    {\"id\": 2, \"vector\": [0.19, 0.81, 0.75, 0.11], \"payload\": {\"city\": [\"Berlin\", \"London\"] }},\n    {\"id\": 3, \"vector\": [0.36, 0.55, 0.47, 0.94], \"payload\": {\"city\": [\"Berlin\", \"Moscow\"] }},\n    {\"id\": 4, \"vector\": [0.18, 0.01, 0.85, 0.80], \"payload\": {\"city\": [\"London\", \"Moscow\"] }},\n    {\"id\": 5, \"vector\": [0.24, 0.18, 0.22, 0.44], \"payload\": {\"count\": [0]}},\n    {\"id\": 6, \"vector\": [0.35, 0.08, 0.11, 0.44]}\n  ]\n}'\n```\nExpected response:\n```\n{\n    \"result\": {\n        \"operation_id\": 0,\n        \"status\": \"completed\"\n    },\n    \"status\": \"ok\",\n    \"time\": 0.000206061\n}\n```\n### Search with filtering\nLet's start with a basic request:\n```\ncurl -L -X POST 'http://localhost:6333/collections/test_collection/points/search' \\ -H 'Content-Type: application/json' \\ --data-raw '{\n    \"vector\": [0.2,0.1,0.9,0.7],\n    \"top\": 3\n}'\n```\nExpected response:\n```\n{\n    \"result\": [\n        { \"id\": 4, \"score\": 1.362, \"payload\": null, \"version\": 0 },\n        { \"id\": 1, \"score\": 1.273, \"payload\": null, \"version\": 0 },\n        { \"id\": 3, \"score\": 1.208, \"payload\": null, \"version\": 0 }\n    ],\n    \"status\": \"ok\",\n    \"time\": 0.000055785\n}\n```\nBut result is different if we add a filter:\n```\ncurl -L -X POST 'http://localhost:6333/collections/test_collection/points/search' \\ -H 'Content-Type: application/json' \\ --data-raw '{\n    \"filter\": {\n        \"should\": [\n            {\n                \"key\": \"city\",\n                \"match\": {\n                    \"value\": \"London\"\n                }\n            }\n        ]\n    },\n    \"vector\": [0.2, 0.1, 0.9, 0.7],\n    \"top\": 3\n}'\n```\nExpected response:\n```\n{\n    \"result\": [\n        { \"id\": 4, \"score\": 1.362, \"payload\": null, \"version\": 0 },\n        { \"id\": 2, \"score\": 0.871, \"payload\": null, \"version\": 0 }\n    ],\n    \"status\": \"ok\",\n    \"time\": 0.000093972\n}\n```\n",
     "contact": {
       "email": "andrey@vasnetsov.com"
     },
@@ -6538,10 +7188,10 @@
         "example": {
           "collections": [
             {
-              "name": "arivx-title"
+              "name": "arxiv-title"
             },
             {
-              "name": "arivx-abstract"
+              "name": "arxiv-abstract"
             },
             {
               "name": "medium-title"
@@ -6580,12 +7230,12 @@
           "optimizer_status": {
             "$ref": "#/components/schemas/OptimizersStatus"
           },
-          "vectors_count": {
-            "description": "DEPRECATED: Approximate number of vectors in collection. All vectors in collection are available for querying. Calculated as `points_count x vectors_per_point`. Where `vectors_per_point` is a number of named vectors in schema.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
+          "warnings": {
+            "description": "Warnings related to the collection",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CollectionWarning"
+            }
           },
           "indexed_vectors_count": {
             "description": "Approximate number of indexed vectors in the collection. Indexed vectors in large segments are faster to query, as it is stored in a specialized vector index.",
@@ -6616,6 +7266,17 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/PayloadIndexInfo"
             }
+          },
+          "update_queue": {
+            "description": "Update queue info",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UpdateQueueInfo"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -6653,6 +7314,18 @@
             "additionalProperties": false
           }
         ]
+      },
+      "CollectionWarning": {
+        "type": "object",
+        "required": [
+          "message"
+        ],
+        "properties": {
+          "message": {
+            "description": "Warning message",
+            "type": "string"
+          }
+        }
       },
       "CollectionConfig": {
         "description": "Information about the collection configuration",
@@ -6696,7 +7369,18 @@
           "strict_mode_config": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/StrictModeConfig"
+                "$ref": "#/components/schemas/StrictModeConfigOutput"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "metadata": {
+            "description": "Arbitrary JSON metadata for the collection This can be used to store application-specific information such as creation time, migration data, inference model info, etc.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Payload"
               },
               {
                 "nullable": true
@@ -6747,6 +7431,13 @@
             "description": "Defines how many additional replicas should be processing read request at the same time. Default value is Auto, which means that fan-out will be determined automatically based on the busyness of the local replica. Having more than 0 might be useful to smooth latency spikes of individual nodes.",
             "type": "integer",
             "format": "uint32",
+            "minimum": 0,
+            "nullable": true
+          },
+          "read_fan_out_delay_ms": {
+            "description": "Define number of milliseconds to wait before attempting to read from another replica. This setting can help to reduce latency spikes in case of occasional slow replicas. Default is 0, which means delayed fan out request is disabled.",
+            "type": "integer",
+            "format": "uint64",
             "minimum": 0,
             "nullable": true
           },
@@ -6874,7 +7565,7 @@
             "nullable": true
           },
           "full_scan_threshold": {
-            "description": "Minimal size (in kilobytes) of vectors for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold_kb` additional indexing won't be used - in this case full-scan search should be preferred by query planner and additional indexing is not required. Note: 1Kb = 1 vector of size 256",
+            "description": "Minimal size threshold (in KiloBytes) below which full-scan is preferred over HNSW search. This measures the total size of vectors being queried against. When the maximum estimated amount of points that a condition satisfies is smaller than `full_scan_threshold_kb`, the query planner will use full-scan search instead of HNSW index traversal for better performance. Note: 1Kb = 1 vector of size 256",
             "type": "integer",
             "format": "uint",
             "minimum": 10,
@@ -6897,6 +7588,11 @@
             "type": "integer",
             "format": "uint",
             "minimum": 0,
+            "nullable": true
+          },
+          "inline_storage": {
+            "description": "Store copies of original and quantized vectors within the HNSW index file. Default: false. Enabling this option will trade the search speed for disk usage by reducing amount of random seeks during the search. Requires quantized vectors to be enabled. Multi-vectors are not supported.",
+            "type": "boolean",
             "nullable": true
           }
         }
@@ -7008,8 +7704,46 @@
           "always_ram": {
             "type": "boolean",
             "nullable": true
+          },
+          "encoding": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BinaryQuantizationEncoding"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "query_encoding": {
+            "description": "Asymmetric quantization configuration allows a query to have different quantization than stored vectors. It can increase the accuracy of search at the cost of performance.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BinaryQuantizationQueryEncoding"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
+      },
+      "BinaryQuantizationEncoding": {
+        "type": "string",
+        "enum": [
+          "one_bit",
+          "two_bits",
+          "one_and_half_bits"
+        ]
+      },
+      "BinaryQuantizationQueryEncoding": {
+        "type": "string",
+        "enum": [
+          "default",
+          "binary",
+          "scalar4bits",
+          "scalar8bits"
+        ]
       },
       "Datatype": {
         "type": "string",
@@ -7130,7 +7864,7 @@
             "minimum": 4
           },
           "full_scan_threshold": {
-            "description": "Minimal size (in KiloBytes) of vectors for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold_kb` additional indexing won't be used - in this case full-scan search should be preferred by query planner and additional indexing is not required. Note: 1Kb = 1 vector of size 256",
+            "description": "Minimal size threshold (in KiloBytes) below which full-scan is preferred over HNSW search. This measures the total size of vectors being queried against. When the maximum estimated amount of points that a condition satisfies is smaller than `full_scan_threshold_kb`, the query planner will use full-scan search instead of HNSW index traversal for better performance. Note: 1Kb = 1 vector of size 256",
             "type": "integer",
             "format": "uint",
             "minimum": 0
@@ -7153,6 +7887,11 @@
             "format": "uint",
             "minimum": 0,
             "nullable": true
+          },
+          "inline_storage": {
+            "description": "Store copies of original and quantized vectors within the HNSW index file. Default: false. Enabling this option will trade the search speed for disk usage by reducing amount of random seeks during the search. Requires quantized vectors to be enabled. Multi-vectors are not supported.",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
@@ -7160,13 +7899,12 @@
         "type": "object",
         "required": [
           "default_segment_number",
-          "deleted_threshold",
-          "flush_interval_sec",
-          "vacuum_min_vector_number"
+          "flush_interval_sec"
         ],
         "properties": {
           "deleted_threshold": {
             "description": "The minimal fraction of deleted vectors in a segment, required to perform segment optimization",
+            "default": 0.2,
             "type": "number",
             "format": "double",
             "maximum": 1,
@@ -7174,6 +7912,7 @@
           },
           "vacuum_min_vector_number": {
             "description": "The minimal number of vectors in a segment, required to perform segment optimization",
+            "default": 1000,
             "type": "integer",
             "format": "uint",
             "minimum": 100
@@ -7195,13 +7934,14 @@
           "memmap_threshold": {
             "description": "Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmapped file.\n\nMemmap storage is disabled by default, to enable it, set this threshold to a reasonable value.\n\nTo disable memmap storage, set this to `0`. Internally it will use the largest threshold possible.\n\nNote: 1Kb = 1 vector of size 256",
             "default": null,
+            "deprecated": true,
             "type": "integer",
             "format": "uint",
             "minimum": 0,
             "nullable": true
           },
           "indexing_threshold": {
-            "description": "Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing\n\nDefault value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.\n\nTo disable vector indexing, set to `0`.\n\nNote: 1kB = 1 vector of size 256.",
+            "description": "Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing\n\nDefault value is 10,000, based on experiments and observations.\n\nTo disable vector indexing, set to `0`.\n\nNote: 1kB = 1 vector of size 256.",
             "default": null,
             "type": "integer",
             "format": "uint",
@@ -7220,6 +7960,12 @@
             "type": "integer",
             "format": "uint",
             "minimum": 0,
+            "nullable": true
+          },
+          "prevent_unoptimized": {
+            "description": "If this option is set, service will try to prevent creation of large unoptimized segments. When enabled, updates may be blocked at request level if there are unoptimized segments larger than indexing threshold. Updates will be resumed when optimization is completed and segments are optimized below the threshold. Using this option may lead to increased delay between submitting an update and its application. Default is disabled.",
+            "default": null,
+            "type": "boolean",
             "nullable": true
           }
         }
@@ -7242,10 +7988,17 @@
             "type": "integer",
             "format": "uint",
             "minimum": 0
+          },
+          "wal_retain_closed": {
+            "description": "Number of closed WAL segments to keep",
+            "default": 1,
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1
           }
         }
       },
-      "StrictModeConfig": {
+      "StrictModeConfigOutput": {
         "type": "object",
         "properties": {
           "enabled": {
@@ -7268,12 +8021,12 @@
             "nullable": true
           },
           "unindexed_filtering_retrieve": {
-            "description": "Allow usage of unindexed fields in retrieval based (eg. search) filters.",
+            "description": "Allow usage of unindexed fields in retrieval based (e.g. search) filters.",
             "type": "boolean",
             "nullable": true
           },
           "unindexed_filtering_update": {
-            "description": "Allow usage of unindexed fields in filtered updates (eg. delete by payload).",
+            "description": "Allow usage of unindexed fields in filtered updates (e.g. delete by payload).",
             "type": "boolean",
             "nullable": true
           },
@@ -7302,6 +8055,13 @@
             "minimum": 0,
             "nullable": true
           },
+          "search_max_batchsize": {
+            "description": "Max batchsize when searching",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
           "max_collection_vector_size_bytes": {
             "description": "Max size of a collections vector storage in bytes, ignoring replicas.",
             "type": "integer",
@@ -7313,18 +8073,25 @@
             "description": "Max number of read operations per minute per replica",
             "type": "integer",
             "format": "uint",
-            "minimum": 1,
+            "minimum": 0,
             "nullable": true
           },
           "write_rate_limit": {
             "description": "Max number of write operations per minute per replica",
             "type": "integer",
             "format": "uint",
-            "minimum": 1,
+            "minimum": 0,
             "nullable": true
           },
           "max_collection_payload_size_bytes": {
             "description": "Max size of a collections payload storage in bytes",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "max_points_count": {
+            "description": "Max number of points estimated in a collection",
             "type": "integer",
             "format": "uint",
             "minimum": 0,
@@ -7348,7 +8115,7 @@
             "description": "Multivector configuration",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/StrictModeMultivectorConfig"
+                "$ref": "#/components/schemas/StrictModeMultivectorConfigOutput"
               },
               {
                 "nullable": true
@@ -7359,49 +8126,64 @@
             "description": "Sparse vector configuration",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/StrictModeSparseConfig"
+                "$ref": "#/components/schemas/StrictModeSparseConfigOutput"
               },
               {
                 "nullable": true
               }
             ]
+          },
+          "max_payload_index_count": {
+            "description": "Max number of payload indexes in a collection",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
           }
         }
       },
-      "StrictModeMultivectorConfig": {
+      "StrictModeMultivectorConfigOutput": {
         "type": "object",
         "additionalProperties": {
-          "$ref": "#/components/schemas/StrictModeMultivector"
+          "$ref": "#/components/schemas/StrictModeMultivectorOutput"
         }
       },
-      "StrictModeMultivector": {
+      "StrictModeMultivectorOutput": {
         "type": "object",
         "properties": {
           "max_vectors": {
             "description": "Max number of vectors in a multivector",
             "type": "integer",
             "format": "uint",
-            "minimum": 1,
+            "minimum": 0,
             "nullable": true
           }
         }
       },
-      "StrictModeSparseConfig": {
+      "StrictModeSparseConfigOutput": {
         "type": "object",
         "additionalProperties": {
-          "$ref": "#/components/schemas/StrictModeSparse"
+          "$ref": "#/components/schemas/StrictModeSparseOutput"
         }
       },
-      "StrictModeSparse": {
+      "StrictModeSparseOutput": {
         "type": "object",
         "properties": {
           "max_length": {
             "description": "Max length of sparse vector",
             "type": "integer",
             "format": "uint",
-            "minimum": 1,
+            "minimum": 0,
             "nullable": true
           }
+        }
+      },
+      "Payload": {
+        "type": "object",
+        "additionalProperties": true,
+        "example": {
+          "city": "London",
+          "color": "green"
         }
       },
       "PayloadIndexInfo": {
@@ -7494,6 +8276,11 @@
             "description": "If true, store the index on disk. Default: false.",
             "type": "boolean",
             "nullable": true
+          },
+          "enable_hnsw": {
+            "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
@@ -7513,22 +8300,27 @@
             "$ref": "#/components/schemas/IntegerIndexType"
           },
           "lookup": {
-            "description": "If true - support direct lookups.",
+            "description": "If true - support direct lookups. Default is true.",
             "type": "boolean",
             "nullable": true
           },
           "range": {
-            "description": "If true - support ranges filters.",
+            "description": "If true - support ranges filters. Default is true.",
             "type": "boolean",
             "nullable": true
           },
           "is_principal": {
-            "description": "If true - use this key to organize storage of the collection data. This option assumes that this key will be used in majority of filtered requests.",
+            "description": "If true - use this key to organize storage of the collection data. This option assumes that this key will be used in majority of filtered requests. Default is false.",
             "type": "boolean",
             "nullable": true
           },
           "on_disk": {
-            "description": "If true, store the index on disk. Default: false.",
+            "description": "If true, store the index on disk. Default: false. Default is false.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "enable_hnsw": {
+            "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
             "type": "boolean",
             "nullable": true
           }
@@ -7558,6 +8350,11 @@
             "description": "If true, store the index on disk. Default: false.",
             "type": "boolean",
             "nullable": true
+          },
+          "enable_hnsw": {
+            "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
@@ -7578,6 +8375,11 @@
           },
           "on_disk": {
             "description": "If true, store the index on disk. Default: false.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "enable_hnsw": {
+            "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
             "type": "boolean",
             "nullable": true
           }
@@ -7620,8 +8422,45 @@
             "type": "boolean",
             "nullable": true
           },
+          "ascii_folding": {
+            "description": "If true, normalize tokens by folding accented characters to ASCII (e.g., \"ação\" -> \"acao\"). Default: false.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "phrase_matching": {
+            "description": "If true, support phrase matching. Default: false.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "stopwords": {
+            "description": "Ignore this set of tokens. Can select from predefined languages and/or provide a custom set.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StopwordsInterface"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
           "on_disk": {
             "description": "If true, store the index on disk. Default: false.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "stemmer": {
+            "description": "Algorithm for stemming. Default: disabled.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StemmingAlgorithm"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "enable_hnsw": {
+            "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
             "type": "boolean",
             "nullable": true
           }
@@ -7642,6 +8481,128 @@
           "multilingual"
         ]
       },
+      "StopwordsInterface": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Language"
+          },
+          {
+            "$ref": "#/components/schemas/StopwordsSet"
+          }
+        ]
+      },
+      "Language": {
+        "type": "string",
+        "enum": [
+          "arabic",
+          "azerbaijani",
+          "basque",
+          "bengali",
+          "catalan",
+          "chinese",
+          "danish",
+          "dutch",
+          "english",
+          "finnish",
+          "french",
+          "german",
+          "greek",
+          "hebrew",
+          "hinglish",
+          "hungarian",
+          "indonesian",
+          "italian",
+          "japanese",
+          "kazakh",
+          "nepali",
+          "norwegian",
+          "portuguese",
+          "romanian",
+          "russian",
+          "slovene",
+          "spanish",
+          "swedish",
+          "tajik",
+          "turkish"
+        ]
+      },
+      "StopwordsSet": {
+        "type": "object",
+        "properties": {
+          "languages": {
+            "description": "Set of languages to use for stopwords. Multiple pre-defined lists of stopwords can be combined.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Language"
+            },
+            "uniqueItems": true,
+            "nullable": true
+          },
+          "custom": {
+            "description": "Custom stopwords set. Will be merged with the languages set.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true,
+            "nullable": true
+          }
+        }
+      },
+      "StemmingAlgorithm": {
+        "description": "Different stemming algorithms with their configs.",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/SnowballParams"
+          }
+        ]
+      },
+      "SnowballParams": {
+        "type": "object",
+        "required": [
+          "language",
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/Snowball"
+          },
+          "language": {
+            "$ref": "#/components/schemas/SnowballLanguage"
+          }
+        }
+      },
+      "Snowball": {
+        "type": "string",
+        "enum": [
+          "snowball"
+        ]
+      },
+      "SnowballLanguage": {
+        "description": "Languages supported by snowball stemmer.",
+        "type": "string",
+        "enum": [
+          "arabic",
+          "armenian",
+          "danish",
+          "dutch",
+          "english",
+          "finnish",
+          "french",
+          "german",
+          "greek",
+          "hungarian",
+          "italian",
+          "norwegian",
+          "portuguese",
+          "romanian",
+          "russian",
+          "spanish",
+          "swedish",
+          "tamil",
+          "turkish"
+        ]
+      },
       "BoolIndexParams": {
         "type": "object",
         "required": [
@@ -7653,6 +8614,11 @@
           },
           "on_disk": {
             "description": "If true, store the index on disk. Default: false.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "enable_hnsw": {
+            "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
             "type": "boolean",
             "nullable": true
           }
@@ -7682,6 +8648,11 @@
             "description": "If true, store the index on disk. Default: false.",
             "type": "boolean",
             "nullable": true
+          },
+          "enable_hnsw": {
+            "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
@@ -7709,6 +8680,11 @@
             "description": "If true, store the index on disk. Default: false.",
             "type": "boolean",
             "nullable": true
+          },
+          "enable_hnsw": {
+            "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
@@ -7717,6 +8693,27 @@
         "enum": [
           "uuid"
         ]
+      },
+      "UpdateQueueInfo": {
+        "type": "object",
+        "required": [
+          "length"
+        ],
+        "properties": {
+          "length": {
+            "description": "Number of elements in the queue",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "deferred_points": {
+            "description": "Number of points that are deferred (i.e hidden from search as they're not yet optimized).",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          }
+        }
       },
       "PointRequest": {
         "type": "object",
@@ -7768,6 +8765,9 @@
             "items": {
               "$ref": "#/components/schemas/ShardKey"
             }
+          },
+          {
+            "$ref": "#/components/schemas/ShardKeyWithFallback"
           }
         ]
       },
@@ -7784,6 +8784,21 @@
             "example": 12
           }
         ]
+      },
+      "ShardKeyWithFallback": {
+        "type": "object",
+        "required": [
+          "fallback",
+          "target"
+        ],
+        "properties": {
+          "target": {
+            "$ref": "#/components/schemas/ShardKey"
+          },
+          "fallback": {
+            "$ref": "#/components/schemas/ShardKey"
+          }
+        }
       },
       "ExtendedPointId": {
         "description": "Type, used for specifying point ID in user interface",
@@ -7932,14 +8947,6 @@
               }
             ]
           }
-        }
-      },
-      "Payload": {
-        "type": "object",
-        "additionalProperties": true,
-        "example": {
-          "city": "London",
-          "color": "green"
         }
       },
       "VectorStructOutput": {
@@ -8215,7 +9222,6 @@
         "properties": {
           "should": {
             "description": "At least one of those conditions should match",
-            "default": null,
             "anyOf": [
               {
                 "$ref": "#/components/schemas/Condition"
@@ -8244,7 +9250,6 @@
           },
           "must": {
             "description": "All conditions must match",
-            "default": null,
             "anyOf": [
               {
                 "$ref": "#/components/schemas/Condition"
@@ -8262,7 +9267,6 @@
           },
           "must_not": {
             "description": "All conditions must NOT match",
-            "default": null,
             "anyOf": [
               {
                 "$ref": "#/components/schemas/Condition"
@@ -8340,7 +9344,7 @@
             ]
           },
           "geo_bounding_box": {
-            "description": "Check if points geo location lies in a given area",
+            "description": "Check if points geolocation lies in a given area",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/GeoBoundingBox"
@@ -8382,6 +9386,16 @@
                 "nullable": true
               }
             ]
+          },
+          "is_empty": {
+            "description": "Check that the field is empty, alternative syntax for `is_empty: \"field_name\"`",
+            "type": "boolean",
+            "nullable": true
+          },
+          "is_null": {
+            "description": "Check that the field is null, alternative syntax for `is_null: \"field_name\"`",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
@@ -8393,6 +9407,12 @@
           },
           {
             "$ref": "#/components/schemas/MatchText"
+          },
+          {
+            "$ref": "#/components/schemas/MatchTextAny"
+          },
+          {
+            "$ref": "#/components/schemas/MatchPhrase"
           },
           {
             "$ref": "#/components/schemas/MatchAny"
@@ -8436,6 +9456,30 @@
         ],
         "properties": {
           "text": {
+            "type": "string"
+          }
+        }
+      },
+      "MatchTextAny": {
+        "description": "Full-text match of at least one token of the string.",
+        "type": "object",
+        "required": [
+          "text_any"
+        ],
+        "properties": {
+          "text_any": {
+            "type": "string"
+          }
+        }
+      },
+      "MatchPhrase": {
+        "description": "Full-text phrase match of the string.",
+        "type": "object",
+        "required": [
+          "phrase"
+        ],
+        "properties": {
+          "phrase": {
             "type": "string"
           }
         }
@@ -8804,7 +9848,6 @@
           },
           "quantization": {
             "description": "Quantization params",
-            "default": null,
             "anyOf": [
               {
                 "$ref": "#/components/schemas/QuantizationSearchParams"
@@ -8818,6 +9861,17 @@
             "description": "If enabled, the engine will only perform search among indexed or small segments. Using this option prevents slow searches in case of delayed index, but does not guarantee that all uploaded vectors will be included in search results",
             "default": false,
             "type": "boolean"
+          },
+          "acorn": {
+            "description": "ACORN search params",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AcornSearchParams"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -8832,16 +9886,33 @@
           },
           "rescore": {
             "description": "If true, use original vectors to re-score top-k results. Might require more time in case if original vectors are stored on disk. If not set, qdrant decides automatically apply rescoring or not.",
-            "default": null,
             "type": "boolean",
             "nullable": true
           },
           "oversampling": {
-            "description": "Oversampling factor for quantization. Default is 1.0.\n\nDefines how many extra vectors should be pre-selected using quantized index, and then re-scored using original vectors.\n\nFor example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will be pre-selected using quantized index, and then top-100 will be returned after re-scoring.",
-            "default": null,
+            "description": "Oversampling factor for quantization. Default is 1.0.\n\nDefines how many extra vectors should be preselected using quantized index, and then re-scored using original vectors.\n\nFor example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will be preselected using quantized index, and then top-100 will be returned after re-scoring.",
             "type": "number",
             "format": "double",
             "minimum": 1,
+            "nullable": true
+          }
+        }
+      },
+      "AcornSearchParams": {
+        "description": "ACORN-related search parameters",
+        "type": "object",
+        "properties": {
+          "enable": {
+            "description": "If true, then ACORN may be used for the HNSW search based on filters selectivity. Improves search recall for searches with multiple low-selectivity payload filters, at cost of performance.",
+            "default": false,
+            "type": "boolean"
+          },
+          "max_selectivity": {
+            "description": "Maximum selectivity of filters to enable ACORN.\n\nIf estimated filters selectivity is higher than this value, ACORN will not be used. Selectivity is estimated as: `estimated number of points satisfying the filters / total number of points`.\n\n0.0 for never, 1.0 for always. Default is 0.4.",
+            "type": "number",
+            "format": "double",
+            "maximum": 1,
+            "minimum": 0,
             "nullable": true
           }
         }
@@ -8936,11 +10007,12 @@
         }
       },
       "UpdateStatus": {
-        "description": "`Acknowledged` - Request is saved to WAL and will be process in a queue. `Completed` - Request is completed, changes are actual.",
+        "description": "`Acknowledged` - Request is saved to WAL and will be process in a queue. `Completed` - Request is completed, changes are actual. `WaitTimeout` - Request is waiting for timeout.",
         "type": "string",
         "enum": [
           "acknowledged",
-          "completed"
+          "completed",
+          "wait_timeout"
         ]
       },
       "RecommendRequest": {
@@ -9096,11 +10168,12 @@
         ]
       },
       "RecommendStrategy": {
-        "description": "How to use positive and negative examples to find the results, default is `average_vector`:\n\n* `average_vector` - Average positive and negative vectors and create a single query with the formula `query = avg_pos + avg_pos - avg_neg`. Then performs normal search.\n\n* `best_score` - Uses custom search objective. Each candidate is compared against all examples, its score is then chosen from the `max(max_pos_score, max_neg_score)`. If the `max_neg_score` is chosen then it is squared and negated, otherwise it is just the `max_pos_score`.",
+        "description": "How to use positive and negative examples to find the results, default is `average_vector`:\n\n* `average_vector` - Average positive and negative vectors and create a single query with the formula `query = avg_pos + avg_pos - avg_neg`. Then performs normal search.\n\n* `best_score` - Uses custom search objective. Each candidate is compared against all examples, its score is then chosen from the `max(max_pos_score, max_neg_score)`. If the `max_neg_score` is chosen then it is squared and negated, otherwise it is just the `max_pos_score`.\n\n* `sum_scores` - Uses custom search objective. Compares against all inputs, sums all the scores. Scores against positive vectors are added, against negatives are subtracted.",
         "type": "string",
         "enum": [
           "average_vector",
-          "best_score"
+          "best_score",
+          "sum_scores"
         ]
       },
       "UsingVector": {
@@ -9415,18 +10488,6 @@
               }
             ]
           },
-          "init_from": {
-            "description": "Specify other collection to copy data from.",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/InitFrom"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
           "quantization_config": {
             "description": "Quantization parameters. If none - quantization is disabled.",
             "default": null,
@@ -9457,6 +10518,17 @@
                 "nullable": true
               }
             ]
+          },
+          "metadata": {
+            "description": "Arbitrary JSON metadata for the collection This can be used to store application-specific information such as creation time, migration data, inference model info, etc.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Payload"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -9476,6 +10548,13 @@
             "format": "uint",
             "minimum": 0,
             "nullable": true
+          },
+          "wal_retain_closed": {
+            "description": "Number of closed WAL segments to retain",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
           }
         }
       },
@@ -9486,13 +10565,15 @@
             "description": "The minimal fraction of deleted vectors in a segment, required to perform segment optimization",
             "type": "number",
             "format": "double",
+            "maximum": 1,
+            "minimum": 0,
             "nullable": true
           },
           "vacuum_min_vector_number": {
             "description": "The minimal number of vectors in a segment, required to perform segment optimization",
             "type": "integer",
             "format": "uint",
-            "minimum": 0,
+            "minimum": 100,
             "nullable": true
           },
           "default_segment_number": {
@@ -9510,7 +10591,8 @@
             "nullable": true
           },
           "memmap_threshold": {
-            "description": "Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmapped file.\n\nMemmap storage is disabled by default, to enable it, set this threshold to a reasonable value.\n\nTo disable memmap storage, set this to `0`.\n\nNote: 1Kb = 1 vector of size 256",
+            "description": "Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmapped file.\n\nMemmap storage is disabled by default, to enable it, set this threshold to a reasonable value.\n\nTo disable memmap storage, set this to `0`.\n\nNote: 1Kb = 1 vector of size 256\n\nDeprecated since Qdrant 1.15.0",
+            "deprecated": true,
             "type": "integer",
             "format": "uint",
             "minimum": 0,
@@ -9540,6 +10622,12 @@
                 "nullable": true
               }
             ]
+          },
+          "prevent_unoptimized": {
+            "description": "If this option is set, service will try to prevent creation of large unoptimized segments. When enabled, updates may be blocked at request level if there are unoptimized segments larger than indexing threshold. Updates will be resumed when optimization is completed and segments are optimized below the threshold. Using this option may lead to increased delay between submitting an update and its application. Default is disabled.",
+            "default": null,
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
@@ -9561,15 +10649,183 @@
           "auto"
         ]
       },
-      "InitFrom": {
-        "description": "Operation for creating new collection and (optionally) specify index params",
+      "StrictModeConfig": {
         "type": "object",
-        "required": [
-          "collection"
-        ],
         "properties": {
-          "collection": {
-            "type": "string"
+          "enabled": {
+            "description": "Whether strict mode is enabled for a collection or not.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "max_query_limit": {
+            "description": "Max allowed `limit` parameter for all APIs that don't have their own max limit.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          },
+          "max_timeout": {
+            "description": "Max allowed `timeout` parameter.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          },
+          "unindexed_filtering_retrieve": {
+            "description": "Allow usage of unindexed fields in retrieval based (e.g. search) filters.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "unindexed_filtering_update": {
+            "description": "Allow usage of unindexed fields in filtered updates (e.g. delete by payload).",
+            "type": "boolean",
+            "nullable": true
+          },
+          "search_max_hnsw_ef": {
+            "description": "Max HNSW ef value allowed in search parameters.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "search_allow_exact": {
+            "description": "Whether exact search is allowed.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "search_max_oversampling": {
+            "description": "Max oversampling value allowed in search.",
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "upsert_max_batchsize": {
+            "description": "Max batchsize when upserting",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "search_max_batchsize": {
+            "description": "Max batchsize when searching",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "max_collection_vector_size_bytes": {
+            "description": "Max size of a collections vector storage in bytes, ignoring replicas.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "read_rate_limit": {
+            "description": "Max number of read operations per minute per replica",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          },
+          "write_rate_limit": {
+            "description": "Max number of write operations per minute per replica",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          },
+          "max_collection_payload_size_bytes": {
+            "description": "Max size of a collections payload storage in bytes",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "max_points_count": {
+            "description": "Max number of points estimated in a collection",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          },
+          "filter_max_conditions": {
+            "description": "Max conditions a filter can have.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "condition_max_size": {
+            "description": "Max size of a condition, eg. items in `MatchAny`.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "multivector_config": {
+            "description": "Multivector strict mode configuration",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StrictModeMultivectorConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "sparse_config": {
+            "description": "Sparse vector strict mode configuration",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StrictModeSparseConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "max_payload_index_count": {
+            "description": "Max number of payload indexes in a collection",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          }
+        }
+      },
+      "StrictModeMultivectorConfig": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/StrictModeMultivector"
+        }
+      },
+      "StrictModeMultivector": {
+        "type": "object",
+        "properties": {
+          "max_vectors": {
+            "description": "Max number of vectors in a multivector",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          }
+        }
+      },
+      "StrictModeSparseConfig": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/StrictModeSparse"
+        }
+      },
+      "StrictModeSparse": {
+        "type": "object",
+        "properties": {
+          "max_length": {
+            "description": "Max length of sparse vector",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
           }
         }
       },
@@ -9648,6 +10904,17 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/StrictModeConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "metadata": {
+            "description": "Metadata to update for the collection. If provided, this will merge with existing metadata. To remove metadata, set it to an empty object.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Payload"
               },
               {
                 "nullable": true
@@ -9738,6 +11005,13 @@
             "description": "Fan-out every read request to these many additional remote nodes (and return first available response)",
             "type": "integer",
             "format": "uint32",
+            "minimum": 0,
+            "nullable": true
+          },
+          "read_fan_out_delay_ms": {
+            "description": "Delay in milliseconds before sending read requests to remote nodes",
+            "type": "integer",
+            "format": "uint64",
             "minimum": 0,
             "nullable": true
           },
@@ -9977,6 +11251,28 @@
                 "nullable": true
               }
             ]
+          },
+          "update_filter": {
+            "description": "Filter to apply when updating existing points. Only points matching this filter will be updated. Points that don't match will keep their current state. New points will be inserted regardless of the filter.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Filter"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "update_mode": {
+            "description": "Mode of the upsert operation: insert_only, upsert (default), update_only",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UpdateMode"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -10109,20 +11405,115 @@
         ],
         "properties": {
           "text": {
-            "description": "Text of the document This field will be used as input for the embedding model",
+            "description": "Text of the document. This field will be used as input for the embedding model.",
             "type": "string",
             "example": "This is a document text"
           },
           "model": {
-            "description": "Name of the model used to generate the vector List of available models depends on a provider",
+            "description": "Name of the model used to generate the vector. List of available models depends on a provider.",
             "type": "string",
             "minLength": 1,
             "example": "jinaai/jina-embeddings-v2-base-en"
           },
           "options": {
-            "description": "Parameters for the model Values of the parameters are model-specific",
+            "description": "Additional options for the model, will be passed to the inference service as-is. See model cards for available options.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DocumentOptions"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
+      },
+      "DocumentOptions": {
+        "description": "Option variants for text documents. Ether general-purpose options or BM25-specific options. BM25-specific will only take effect if the `qdrant/bm25` is specified as a model.",
+        "anyOf": [
+          {
             "type": "object",
-            "additionalProperties": true,
+            "additionalProperties": true
+          },
+          {
+            "$ref": "#/components/schemas/Bm25Config"
+          }
+        ]
+      },
+      "Bm25Config": {
+        "description": "Configuration of the local bm25 models.",
+        "type": "object",
+        "properties": {
+          "k": {
+            "description": "Controls term frequency saturation. Higher values mean term frequency has more impact. Default is 1.2",
+            "default": 1.2,
+            "type": "number",
+            "format": "double"
+          },
+          "b": {
+            "description": "Controls document length normalization. Ranges from 0 (no normalization) to 1 (full normalization). Higher values mean longer documents have less impact. Default is 0.75.",
+            "default": 0.75,
+            "type": "number",
+            "format": "double"
+          },
+          "avg_len": {
+            "description": "Expected average document length in the collection. Default is 256.",
+            "default": 256,
+            "type": "number",
+            "format": "double"
+          },
+          "tokenizer": {
+            "$ref": "#/components/schemas/TokenizerType"
+          },
+          "language": {
+            "description": "Defines which language to use for text preprocessing. This parameter is used to construct default stopwords filter and stemmer. To disable language-specific processing, set this to `\"language\": \"none\"`. If not specified, English is assumed.",
+            "type": "string",
+            "nullable": true
+          },
+          "lowercase": {
+            "description": "Lowercase the text before tokenization. Default is `true`.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "ascii_folding": {
+            "description": "If true, normalize tokens by folding accented characters to ASCII (e.g., \"ação\" -> \"acao\"). Default is `false`.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "stopwords": {
+            "description": "Configuration of the stopwords filter. Supports list of pre-defined languages and custom stopwords. Default: initialized for specified `language` or English if not specified.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StopwordsInterface"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "stemmer": {
+            "description": "Configuration of the stemmer. Processes tokens to their root form. Default: initialized Snowball stemmer for specified `language` or English if not specified.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StemmingAlgorithm"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "min_token_len": {
+            "description": "Minimum token length to keep. If token is shorter than this, it will be discarded. Default is `None`, which means no minimum length.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "max_token_len": {
+            "description": "Maximum token length to keep. If token is longer than this, it will be discarded. Default is `None`, which means no maximum length.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
             "nullable": true
           }
         }
@@ -10140,7 +11531,7 @@
             "example": "https://example.com/image.jpg"
           },
           "model": {
-            "description": "Name of the model used to generate the vector List of available models depends on a provider",
+            "description": "Name of the model used to generate the vector. List of available models depends on a provider.",
             "type": "string",
             "minLength": 1,
             "example": "Qdrant/clip-ViT-B-32-vision"
@@ -10162,10 +11553,10 @@
         ],
         "properties": {
           "object": {
-            "description": "Arbitrary data, used as input for the embedding model Used if the model requires more than one input or a custom input"
+            "description": "Arbitrary data, used as input for the embedding model. Used if the model requires more than one input or a custom input."
           },
           "model": {
-            "description": "Name of the model used to generate the vector List of available models depends on a provider",
+            "description": "Name of the model used to generate the vector. List of available models depends on a provider.",
             "type": "string",
             "minLength": 1,
             "example": "jinaai/jina-embeddings-v2-base-en"
@@ -10177,6 +11568,15 @@
             "nullable": true
           }
         }
+      },
+      "UpdateMode": {
+        "description": "Defines the mode of the upsert operation\n\n* `upsert` - default mode, insert new points, update existing points * `insert_only` - only insert new points, do not update existing points * `update_only` - only update existing points, do not insert new points",
+        "type": "string",
+        "enum": [
+          "upsert",
+          "insert_only",
+          "update_only"
+        ]
       },
       "PointsList": {
         "type": "object",
@@ -10194,6 +11594,28 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/ShardKeySelector"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "update_filter": {
+            "description": "Filter to apply when updating existing points. Only points matching this filter will be updated. Points that don't match will keep their current state. New points will be inserted regardless of the filter.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Filter"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "update_mode": {
+            "description": "Mode of the upsert operation: insert_only, upsert (default), update_only",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UpdateMode"
               },
               {
                 "nullable": true
@@ -10785,7 +12207,9 @@
           "PartialSnapshot",
           "Recovery",
           "Resharding",
-          "ReshardingScaleDown"
+          "ReshardingScaleDown",
+          "ActiveRead",
+          "ManualRecovery"
         ]
       },
       "RemoteShardInfo": {
@@ -10839,7 +12263,7 @@
             "minimum": 0
           },
           "to_shard_id": {
-            "description": "Target shard ID if different than source shard ID\n\nUsed exclusively with `ReshardStreamRecords` transfer method.",
+            "description": "Target shard ID if different than source shard ID\n\nUsed exclusively with `ReshardingStreamRecords` transfer method.",
             "type": "integer",
             "format": "uint32",
             "minimum": 0,
@@ -10879,36 +12303,13 @@
         }
       },
       "ShardTransferMethod": {
-        "description": "Methods for transferring a shard from one node to another.",
-        "oneOf": [
-          {
-            "description": "Stream all shard records in batches until the whole shard is transferred.",
-            "type": "string",
-            "enum": [
-              "stream_records"
-            ]
-          },
-          {
-            "description": "Snapshot the shard, transfer and restore it on the receiver.",
-            "type": "string",
-            "enum": [
-              "snapshot"
-            ]
-          },
-          {
-            "description": "Attempt to transfer shard difference by WAL delta.",
-            "type": "string",
-            "enum": [
-              "wal_delta"
-            ]
-          },
-          {
-            "description": "Shard transfer for resharding: stream all records in batches until all points are transferred.",
-            "type": "string",
-            "enum": [
-              "resharding_stream_records"
-            ]
-          }
+        "description": "Methods for transferring a shard from one node to another.\n\n- `stream_records` - Stream all shard records in batches until the whole shard is transferred.\n\n- `snapshot` - Snapshot the shard, transfer and restore it on the receiver.\n\n- `wal_delta` - Attempt to transfer shard difference by WAL delta.\n\n- `resharding_stream_records` - Shard transfer for resharding: stream all records in batches until all points are transferred.",
+        "type": "string",
+        "enum": [
+          "stream_records",
+          "snapshot",
+          "wal_delta",
+          "resharding_stream_records"
         ]
       },
       "ReshardingInfo": {
@@ -10945,28 +12346,16 @@
         }
       },
       "ReshardingDirection": {
-        "description": "Resharding direction, scale up or down in number of shards",
-        "oneOf": [
-          {
-            "description": "Scale up, add a new shard",
-            "type": "string",
-            "enum": [
-              "up"
-            ]
-          },
-          {
-            "description": "Scale down, remove a shard",
-            "type": "string",
-            "enum": [
-              "down"
-            ]
-          }
+        "description": "Resharding direction, scale up or down in number of shards\n\n- `up` - Scale up, add a new shard\n\n- `down` - Scale down, remove a shard",
+        "type": "string",
+        "enum": [
+          "up",
+          "down"
         ]
       },
       "TelemetryData": {
         "type": "object",
         "required": [
-          "app",
           "collections",
           "id"
         ],
@@ -10975,7 +12364,14 @@
             "type": "string"
           },
           "app": {
-            "$ref": "#/components/schemas/AppBuildTelemetry"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AppBuildTelemetry"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "collections": {
             "$ref": "#/components/schemas/CollectionsTelemetry"
@@ -11046,6 +12442,26 @@
               }
             ]
           },
+          "runtime_features": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FeatureFlags"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "hnsw_global_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HnswGlobalConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
           "system": {
             "anyOf": [
               {
@@ -11064,6 +12480,16 @@
             "type": "boolean",
             "nullable": true
           },
+          "audit": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AuditTelemetry"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
           "startup": {
             "type": "string",
             "format": "date-time"
@@ -11076,14 +12502,12 @@
           "debug",
           "gpu",
           "recovery_mode",
+          "rocksdb",
           "service_debug_feature",
-          "web_feature"
+          "staging"
         ],
         "properties": {
           "debug": {
-            "type": "boolean"
-          },
-          "web_feature": {
             "type": "boolean"
           },
           "service_debug_feature": {
@@ -11094,6 +12518,50 @@
           },
           "gpu": {
             "type": "boolean"
+          },
+          "rocksdb": {
+            "type": "boolean"
+          },
+          "staging": {
+            "type": "boolean"
+          }
+        }
+      },
+      "FeatureFlags": {
+        "type": "object",
+        "properties": {
+          "all": {
+            "description": "Magic feature flag that enables all features.\n\nNote that this will only be applied to all flags when passed into [`init_feature_flags`].",
+            "default": false,
+            "type": "boolean"
+          },
+          "incremental_hnsw_building": {
+            "description": "Use incremental HNSW building.\n\nEnabled by default in Qdrant 1.14.1.",
+            "default": true,
+            "type": "boolean"
+          },
+          "appendable_quantization": {
+            "description": "Use appendable quantization in appendable plain segments.\n\nEnabled by default in Qdrant 1.16.0.",
+            "default": true,
+            "type": "boolean"
+          },
+          "single_file_mmap_vector_storage": {
+            "description": "Use single-file mmap in-ram vector storage (InRamMmap)\n\nEnabled by default in Qdrant 1.17.1+",
+            "default": false,
+            "type": "boolean"
+          }
+        }
+      },
+      "HnswGlobalConfig": {
+        "type": "object",
+        "properties": {
+          "healing_threshold": {
+            "description": "Enable HNSW healing if the ratio of missing points is no more than this value. To disable healing completely, set this value to `0.0`.",
+            "default": 0.3,
+            "type": "number",
+            "format": "double",
+            "maximum": 1,
+            "minimum": 0
           }
         }
       },
@@ -11174,6 +12642,41 @@
           }
         }
       },
+      "AuditTelemetry": {
+        "type": "object",
+        "required": [
+          "dir",
+          "log_api",
+          "max_log_files",
+          "rotation",
+          "trust_forwarded_headers"
+        ],
+        "properties": {
+          "dir": {
+            "type": "string"
+          },
+          "rotation": {
+            "type": "string"
+          },
+          "max_log_files": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "trust_forwarded_headers": {
+            "type": "boolean"
+          },
+          "log_api": {
+            "type": "boolean"
+          },
+          "dir_size_bytes": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          }
+        }
+      },
       "CollectionsTelemetry": {
         "type": "object",
         "required": [
@@ -11185,10 +12688,23 @@
             "format": "uint",
             "minimum": 0
           },
+          "max_collections": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
           "collections": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/CollectionTelemetryEnum"
+            },
+            "nullable": true
+          },
+          "snapshots": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CollectionSnapshotTelemetry"
             },
             "nullable": true
           }
@@ -11207,13 +12723,7 @@
       "CollectionTelemetry": {
         "type": "object",
         "required": [
-          "config",
-          "id",
-          "init_time_ms",
-          "resharding",
-          "shard_clean_tasks",
-          "shards",
-          "transfers"
+          "id"
         ],
         "properties": {
           "id": {
@@ -11222,38 +12732,50 @@
           "init_time_ms": {
             "type": "integer",
             "format": "uint64",
-            "minimum": 0
+            "minimum": 0,
+            "nullable": true
           },
           "config": {
-            "$ref": "#/components/schemas/CollectionConfigInternal"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CollectionConfigTelemetry"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "shards": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ReplicaSetTelemetry"
-            }
+            },
+            "nullable": true
           },
           "transfers": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ShardTransferInfo"
-            }
+            },
+            "nullable": true
           },
           "resharding": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ReshardingInfo"
-            }
+            },
+            "nullable": true
           },
           "shard_clean_tasks": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ShardCleanStatusTelemetry"
-            }
+            },
+            "nullable": true
           }
         }
       },
-      "CollectionConfigInternal": {
+      "CollectionConfigTelemetry": {
         "type": "object",
         "required": [
           "hnsw_config",
@@ -11288,7 +12810,7 @@
           "strict_mode_config": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/StrictModeConfig"
+                "$ref": "#/components/schemas/StrictModeConfigOutput"
               },
               {
                 "nullable": true
@@ -11300,6 +12822,17 @@
             "type": "string",
             "format": "uuid",
             "nullable": true
+          },
+          "metadata": {
+            "description": "Arbitrary JSON metadata for the collection",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Payload"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -11347,14 +12880,22 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/ReplicaState"
             }
+          },
+          "partial_snapshot": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PartialSnapshotTelemetry"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
       "LocalShardTelemetry": {
         "type": "object",
         "required": [
-          "optimizations",
-          "segments",
           "total_optimized_points"
         ],
         "properties": {
@@ -11378,18 +12919,84 @@
             "format": "uint",
             "minimum": 0
           },
+          "vectors_size_bytes": {
+            "description": "An ESTIMATION of effective amount of bytes used for vectors Do NOT rely on this number unless you know what you are doing",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "payloads_size_bytes": {
+            "description": "An estimation of the effective amount of bytes used for payloads Do NOT rely on this number unless you know what you are doing",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "num_points": {
+            "description": "Sum of segment points This is an approximate number Do NOT rely on this number unless you know what you are doing",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "num_vectors": {
+            "description": "Sum of number of vectors in all segments This is an approximate number Do NOT rely on this number unless you know what you are doing",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "num_vectors_by_name": {
+            "description": "Sum of number of vectors across all segments, grouped by their name. This is an approximate number. Do NOT rely on this number unless you know what you are doing",
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "nullable": true
+          },
           "segments": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/SegmentTelemetry"
-            }
+            },
+            "nullable": true
           },
           "optimizations": {
-            "$ref": "#/components/schemas/OptimizerTelemetry"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OptimizerTelemetry"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "async_scorer": {
             "type": "boolean",
             "nullable": true
+          },
+          "indexed_only_excluded_vectors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "nullable": true
+          },
+          "update_queue": {
+            "description": "Update queue status",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardUpdateQueueInfo"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -11446,10 +13053,15 @@
           "payloads_size_bytes",
           "ram_usage_bytes",
           "segment_type",
+          "uuid",
           "vector_data",
           "vectors_size_bytes"
         ],
         "properties": {
+          "uuid": {
+            "type": "string",
+            "format": "uuid"
+          },
           "segment_type": {
             "$ref": "#/components/schemas/SegmentType"
           },
@@ -11462,6 +13074,18 @@
             "type": "integer",
             "format": "uint",
             "minimum": 0
+          },
+          "num_deferred_points": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "num_deleted_deferred_points": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
           },
           "num_indexed_vectors": {
             "type": "integer",
@@ -11509,6 +13133,13 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/VectorDataInfo"
             }
+          },
+          "deferred_internal_id": {
+            "description": "Internal ID from which points are deferred (hidden from reads). Only set for appendable segments.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0,
+            "nullable": true
           }
         }
       },
@@ -11660,6 +13291,20 @@
             "enum": [
               "InRamChunkedMmap"
             ]
+          },
+          {
+            "description": "Storage in a single mmap file, not appendable Pre-fetched into RAM on load",
+            "type": "string",
+            "enum": [
+              "InRamMmap"
+            ]
+          },
+          {
+            "description": "Placeholder storage: contains no data, all vectors reported as deleted. Used for newly created named vectors on immutable segments. No files on disk, reconstructed from config on load.",
+            "type": "string",
+            "enum": [
+              "Empty"
+            ]
           }
         ]
       },
@@ -11727,6 +13372,17 @@
           },
           "storage_type": {
             "$ref": "#/components/schemas/SparseVectorStorageType"
+          },
+          "modifier": {
+            "description": "Configures addition value modifications for sparse vectors. Default: none",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Modifier"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -11789,17 +13445,17 @@
       "SparseVectorStorageType": {
         "oneOf": [
           {
-            "description": "Storage on disk",
-            "type": "string",
-            "enum": [
-              "on_disk"
-            ]
-          },
-          {
-            "description": "Storage in memory maps",
+            "description": "Storage in memory maps (gridstore storage)",
             "type": "string",
             "enum": [
               "mmap"
+            ]
+          },
+          {
+            "description": "Placeholder storage: contains no data, all vectors reported as deleted. Used for newly created sparse named vectors on immutable segments.",
+            "type": "string",
+            "enum": [
+              "empty"
             ]
           }
         ]
@@ -11816,35 +13472,21 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "in_memory"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "type"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "on_disk"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "type"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
                   "mmap"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "in_ram_mmap"
                 ]
               }
             }
@@ -11901,8 +13543,7 @@
       "OperationDurationStatistics": {
         "type": "object",
         "required": [
-          "count",
-          "total_duration_micros"
+          "count"
         ],
         "properties": {
           "count": {
@@ -11913,7 +13554,8 @@
           "fail_count": {
             "type": "integer",
             "format": "uint",
-            "minimum": 0
+            "minimum": 0,
+            "nullable": true
           },
           "avg_duration_micros": {
             "description": "The average time taken by 128 latest operations, calculated as a weighted mean.",
@@ -11937,7 +13579,8 @@
             "description": "The total duration of all operations in microseconds.",
             "type": "integer",
             "format": "uint64",
-            "minimum": 0
+            "minimum": 0,
+            "nullable": true
           },
           "last_responded": {
             "type": "string",
@@ -11949,6 +13592,7 @@
       "PayloadIndexTelemetry": {
         "type": "object",
         "required": [
+          "index_type",
           "points_count",
           "points_values_count"
         ],
@@ -11956,6 +13600,9 @@
           "field_name": {
             "type": "string",
             "nullable": true
+          },
+          "index_type": {
+            "type": "string"
           },
           "points_values_count": {
             "description": "The amount of values indexed for all points.",
@@ -11980,7 +13627,6 @@
       "OptimizerTelemetry": {
         "type": "object",
         "required": [
-          "log",
           "optimizations",
           "status"
         ],
@@ -11995,7 +13641,8 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/TrackerTelemetry"
-            }
+            },
+            "nullable": true
           }
         }
       },
@@ -12005,21 +13652,36 @@
         "required": [
           "name",
           "segment_ids",
+          "segment_uuids",
           "start_at",
-          "status"
+          "status",
+          "uuid"
         ],
         "properties": {
           "name": {
             "description": "Name of the optimizer",
             "type": "string"
           },
+          "uuid": {
+            "description": "UUID of the upcoming segment being created by the optimizer",
+            "type": "string",
+            "format": "uuid"
+          },
           "segment_ids": {
-            "description": "Segment IDs being optimized",
+            "description": "Internal segment IDs being optimized. These are local and in-memory, meaning that they can refer to different segments after a service restart.",
             "type": "array",
             "items": {
               "type": "integer",
               "format": "uint",
               "minimum": 0
+            }
+          },
+          "segment_uuids": {
+            "description": "Segment UUIDs being optimized. Refers to same segments as in `segment_ids`, but trackable across restarts, and reflect their directory name.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
             }
           },
           "status": {
@@ -12074,12 +13736,39 @@
           }
         ]
       },
+      "ShardUpdateQueueInfo": {
+        "type": "object",
+        "required": [
+          "length"
+        ],
+        "properties": {
+          "length": {
+            "description": "Number of elements in the queue",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "op_num": {
+            "description": "last operation number processed",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "deferred_points": {
+            "description": "Number of points that are deferred (i.e hidden from search as they're not yet optimized).",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          }
+        }
+      },
       "RemoteShardTelemetry": {
         "type": "object",
         "required": [
-          "searches",
-          "shard_id",
-          "updates"
+          "peer_id",
+          "shard_id"
         ],
         "properties": {
           "shard_id": {
@@ -12090,14 +13779,50 @@
           "peer_id": {
             "type": "integer",
             "format": "uint64",
-            "minimum": 0,
-            "nullable": true
+            "minimum": 0
           },
           "searches": {
-            "$ref": "#/components/schemas/OperationDurationStatistics"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OperationDurationStatistics"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "updates": {
-            "$ref": "#/components/schemas/OperationDurationStatistics"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OperationDurationStatistics"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
+      },
+      "PartialSnapshotTelemetry": {
+        "type": "object",
+        "required": [
+          "is_recovering",
+          "ongoing_create_snapshot_requests",
+          "recovery_timestamp"
+        ],
+        "properties": {
+          "ongoing_create_snapshot_requests": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "is_recovering": {
+            "type": "boolean"
+          },
+          "recovery_timestamp": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
           }
         }
       },
@@ -12182,6 +13907,35 @@
           }
         }
       },
+      "CollectionSnapshotTelemetry": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "running_snapshots": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "running_snapshot_recovery": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "total_snapshot_creations": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          }
+        }
+      },
       "ClusterTelemetry": {
         "type": "object",
         "required": [
@@ -12218,9 +13972,20 @@
             },
             "nullable": true
           },
+          "peer_metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/PeerMetadata"
+            },
+            "nullable": true
+          },
           "metadata": {
             "type": "object",
             "additionalProperties": true,
+            "nullable": true
+          },
+          "resharding_enabled": {
+            "type": "boolean",
             "nullable": true
           }
         }
@@ -12339,6 +14104,19 @@
           }
         }
       },
+      "PeerMetadata": {
+        "description": "Metadata describing extra properties for each peer",
+        "type": "object",
+        "required": [
+          "version"
+        ],
+        "properties": {
+          "version": {
+            "description": "Peer Qdrant version",
+            "type": "string"
+          }
+        }
+      },
       "RequestsTelemetry": {
         "type": "object",
         "required": [
@@ -12368,6 +14146,18 @@
                 "$ref": "#/components/schemas/OperationDurationStatistics"
               }
             }
+          },
+          "per_collection_responses": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/OperationDurationStatistics"
+                }
+              }
+            }
           }
         }
       },
@@ -12380,7 +14170,22 @@
           "responses": {
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/components/schemas/OperationDurationStatistics"
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/OperationDurationStatistics"
+              }
+            }
+          },
+          "per_collection_responses": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/OperationDurationStatistics"
+                }
+              }
             }
           }
         }
@@ -12446,8 +14251,12 @@
         "type": "object",
         "required": [
           "cpu",
-          "io_read",
-          "io_write"
+          "payload_index_io_read",
+          "payload_index_io_write",
+          "payload_io_read",
+          "payload_io_write",
+          "vector_io_read",
+          "vector_io_write"
         ],
         "properties": {
           "cpu": {
@@ -12455,12 +14264,32 @@
             "format": "uint",
             "minimum": 0
           },
-          "io_read": {
+          "payload_io_read": {
             "type": "integer",
             "format": "uint",
             "minimum": 0
           },
-          "io_write": {
+          "payload_io_write": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "payload_index_io_read": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "payload_index_io_write": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "vector_io_read": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "vector_io_write": {
             "type": "integer",
             "format": "uint",
             "minimum": 0
@@ -12495,6 +14324,9 @@
           },
           {
             "$ref": "#/components/schemas/AbortReshardingOperation"
+          },
+          {
+            "$ref": "#/components/schemas/ReplicatePointsOperation"
           }
         ]
       },
@@ -12701,6 +14533,17 @@
               "minimum": 0
             },
             "nullable": true
+          },
+          "initial_state": {
+            "description": "Initial state of the shards for this key If not specified, will be `Initializing` first and then `Active` Warning: do not change this unless you know what you are doing",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReplicaState"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -12818,6 +14661,42 @@
       "AbortResharding": {
         "type": "object"
       },
+      "ReplicatePointsOperation": {
+        "type": "object",
+        "required": [
+          "replicate_points"
+        ],
+        "properties": {
+          "replicate_points": {
+            "$ref": "#/components/schemas/ReplicatePoints"
+          }
+        }
+      },
+      "ReplicatePoints": {
+        "type": "object",
+        "required": [
+          "from_shard_key",
+          "to_shard_key"
+        ],
+        "properties": {
+          "filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Filter"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "from_shard_key": {
+            "$ref": "#/components/schemas/ShardKey"
+          },
+          "to_shard_key": {
+            "$ref": "#/components/schemas/ShardKey"
+          }
+        }
+      },
       "SearchRequestBatch": {
         "type": "object",
         "required": [
@@ -12843,21 +14722,6 @@
             "items": {
               "$ref": "#/components/schemas/RecommendRequest"
             }
-          }
-        }
-      },
-      "LocksOption": {
-        "type": "object",
-        "required": [
-          "write"
-        ],
-        "properties": {
-          "error_message": {
-            "type": "string",
-            "nullable": true
-          },
-          "write": {
-            "type": "boolean"
           }
         }
       },
@@ -12989,6 +14853,16 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/ShardKeySelector"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "update_filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Filter"
               },
               {
                 "nullable": true
@@ -14054,7 +15928,16 @@
             "$ref": "#/components/schemas/FusionQuery"
           },
           {
+            "$ref": "#/components/schemas/RrfQuery"
+          },
+          {
+            "$ref": "#/components/schemas/FormulaQuery"
+          },
+          {
             "$ref": "#/components/schemas/SampleQuery"
+          },
+          {
+            "$ref": "#/components/schemas/RelevanceFeedbackQuery"
           }
         ]
       },
@@ -14066,6 +15949,39 @@
         "properties": {
           "nearest": {
             "$ref": "#/components/schemas/VectorInput"
+          },
+          "mmr": {
+            "description": "Perform MMR (Maximal Marginal Relevance) reranking after search, using the same vector in this query to calculate relevance.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Mmr"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
+      },
+      "Mmr": {
+        "description": "Maximal Marginal Relevance (MMR) algorithm for re-ranking the points.",
+        "type": "object",
+        "properties": {
+          "diversity": {
+            "description": "Tunable parameter for the MMR algorithm. Determines the balance between diversity and relevance.\n\nA higher value favors diversity (dissimilarity to selected results), while a lower value favors relevance (similarity to the query vector).\n\nMust be in the range [0, 1]. Default value is 0.5.",
+            "type": "number",
+            "format": "float",
+            "maximum": 1,
+            "minimum": 0,
+            "nullable": true
+          },
+          "candidates_limit": {
+            "description": "The maximum number of candidates to consider for re-ranking.\n\nIf not specified, the `limit` value is used.",
+            "type": "integer",
+            "format": "uint",
+            "maximum": 16384,
+            "minimum": 0,
+            "nullable": true
           }
         }
       },
@@ -14217,12 +16133,391 @@
         }
       },
       "Fusion": {
-        "description": "Fusion algorithm allows to combine results of multiple prefetches.\n\nAvailable fusion algorithms:\n\n* `rrf` - Reciprocal Rank Fusion * `dbsf` - Distribution-Based Score Fusion",
+        "description": "Fusion algorithm allows to combine results of multiple prefetches.\n\nAvailable fusion algorithms:\n\n* `rrf` - Reciprocal Rank Fusion (with default parameters) * `dbsf` - Distribution-Based Score Fusion",
         "type": "string",
         "enum": [
           "rrf",
           "dbsf"
         ]
+      },
+      "RrfQuery": {
+        "type": "object",
+        "required": [
+          "rrf"
+        ],
+        "properties": {
+          "rrf": {
+            "$ref": "#/components/schemas/Rrf"
+          }
+        }
+      },
+      "Rrf": {
+        "description": "Parameters for Reciprocal Rank Fusion",
+        "type": "object",
+        "properties": {
+          "k": {
+            "description": "K parameter for reciprocal rank fusion",
+            "default": null,
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          },
+          "weights": {
+            "description": "Weights for each prefetch source. Higher weight gives more influence on the final ranking. If not specified, all prefetches are weighted equally. The number of weights should match the number of prefetches.",
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "float"
+            },
+            "nullable": true
+          }
+        }
+      },
+      "FormulaQuery": {
+        "type": "object",
+        "required": [
+          "formula"
+        ],
+        "properties": {
+          "formula": {
+            "$ref": "#/components/schemas/Expression"
+          },
+          "defaults": {
+            "default": {},
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "Expression": {
+        "anyOf": [
+          {
+            "type": "number",
+            "format": "float"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/Condition"
+          },
+          {
+            "$ref": "#/components/schemas/GeoDistance"
+          },
+          {
+            "$ref": "#/components/schemas/DatetimeExpression"
+          },
+          {
+            "$ref": "#/components/schemas/DatetimeKeyExpression"
+          },
+          {
+            "$ref": "#/components/schemas/MultExpression"
+          },
+          {
+            "$ref": "#/components/schemas/SumExpression"
+          },
+          {
+            "$ref": "#/components/schemas/NegExpression"
+          },
+          {
+            "$ref": "#/components/schemas/AbsExpression"
+          },
+          {
+            "$ref": "#/components/schemas/DivExpression"
+          },
+          {
+            "$ref": "#/components/schemas/SqrtExpression"
+          },
+          {
+            "$ref": "#/components/schemas/PowExpression"
+          },
+          {
+            "$ref": "#/components/schemas/ExpExpression"
+          },
+          {
+            "$ref": "#/components/schemas/Log10Expression"
+          },
+          {
+            "$ref": "#/components/schemas/LnExpression"
+          },
+          {
+            "$ref": "#/components/schemas/LinDecayExpression"
+          },
+          {
+            "$ref": "#/components/schemas/ExpDecayExpression"
+          },
+          {
+            "$ref": "#/components/schemas/GaussDecayExpression"
+          }
+        ]
+      },
+      "GeoDistance": {
+        "type": "object",
+        "required": [
+          "geo_distance"
+        ],
+        "properties": {
+          "geo_distance": {
+            "$ref": "#/components/schemas/GeoDistanceParams"
+          }
+        }
+      },
+      "GeoDistanceParams": {
+        "type": "object",
+        "required": [
+          "origin",
+          "to"
+        ],
+        "properties": {
+          "origin": {
+            "$ref": "#/components/schemas/GeoPoint"
+          },
+          "to": {
+            "description": "Payload field with the destination geo point",
+            "type": "string"
+          }
+        }
+      },
+      "DatetimeExpression": {
+        "type": "object",
+        "required": [
+          "datetime"
+        ],
+        "properties": {
+          "datetime": {
+            "type": "string"
+          }
+        }
+      },
+      "DatetimeKeyExpression": {
+        "type": "object",
+        "required": [
+          "datetime_key"
+        ],
+        "properties": {
+          "datetime_key": {
+            "type": "string"
+          }
+        }
+      },
+      "MultExpression": {
+        "type": "object",
+        "required": [
+          "mult"
+        ],
+        "properties": {
+          "mult": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Expression"
+            }
+          }
+        }
+      },
+      "SumExpression": {
+        "type": "object",
+        "required": [
+          "sum"
+        ],
+        "properties": {
+          "sum": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Expression"
+            }
+          }
+        }
+      },
+      "NegExpression": {
+        "type": "object",
+        "required": [
+          "neg"
+        ],
+        "properties": {
+          "neg": {
+            "$ref": "#/components/schemas/Expression"
+          }
+        }
+      },
+      "AbsExpression": {
+        "type": "object",
+        "required": [
+          "abs"
+        ],
+        "properties": {
+          "abs": {
+            "$ref": "#/components/schemas/Expression"
+          }
+        }
+      },
+      "DivExpression": {
+        "type": "object",
+        "required": [
+          "div"
+        ],
+        "properties": {
+          "div": {
+            "$ref": "#/components/schemas/DivParams"
+          }
+        }
+      },
+      "DivParams": {
+        "type": "object",
+        "required": [
+          "left",
+          "right"
+        ],
+        "properties": {
+          "left": {
+            "$ref": "#/components/schemas/Expression"
+          },
+          "right": {
+            "$ref": "#/components/schemas/Expression"
+          },
+          "by_zero_default": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          }
+        }
+      },
+      "SqrtExpression": {
+        "type": "object",
+        "required": [
+          "sqrt"
+        ],
+        "properties": {
+          "sqrt": {
+            "$ref": "#/components/schemas/Expression"
+          }
+        }
+      },
+      "PowExpression": {
+        "type": "object",
+        "required": [
+          "pow"
+        ],
+        "properties": {
+          "pow": {
+            "$ref": "#/components/schemas/PowParams"
+          }
+        }
+      },
+      "PowParams": {
+        "type": "object",
+        "required": [
+          "base",
+          "exponent"
+        ],
+        "properties": {
+          "base": {
+            "$ref": "#/components/schemas/Expression"
+          },
+          "exponent": {
+            "$ref": "#/components/schemas/Expression"
+          }
+        }
+      },
+      "ExpExpression": {
+        "type": "object",
+        "required": [
+          "exp"
+        ],
+        "properties": {
+          "exp": {
+            "$ref": "#/components/schemas/Expression"
+          }
+        }
+      },
+      "Log10Expression": {
+        "type": "object",
+        "required": [
+          "log10"
+        ],
+        "properties": {
+          "log10": {
+            "$ref": "#/components/schemas/Expression"
+          }
+        }
+      },
+      "LnExpression": {
+        "type": "object",
+        "required": [
+          "ln"
+        ],
+        "properties": {
+          "ln": {
+            "$ref": "#/components/schemas/Expression"
+          }
+        }
+      },
+      "LinDecayExpression": {
+        "type": "object",
+        "required": [
+          "lin_decay"
+        ],
+        "properties": {
+          "lin_decay": {
+            "$ref": "#/components/schemas/DecayParamsExpression"
+          }
+        }
+      },
+      "DecayParamsExpression": {
+        "type": "object",
+        "required": [
+          "x"
+        ],
+        "properties": {
+          "x": {
+            "$ref": "#/components/schemas/Expression"
+          },
+          "target": {
+            "description": "The target value to start decaying from. Defaults to 0.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Expression"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "scale": {
+            "description": "The scale factor of the decay, in terms of `x`. Defaults to 1.0. Must be a non-zero positive number.",
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "midpoint": {
+            "description": "The midpoint of the decay. Should be between 0 and 1.Defaults to 0.5. Output will be this value when `|x - target| == scale`.",
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          }
+        }
+      },
+      "ExpDecayExpression": {
+        "type": "object",
+        "required": [
+          "exp_decay"
+        ],
+        "properties": {
+          "exp_decay": {
+            "$ref": "#/components/schemas/DecayParamsExpression"
+          }
+        }
+      },
+      "GaussDecayExpression": {
+        "type": "object",
+        "required": [
+          "gauss_decay"
+        ],
+        "properties": {
+          "gauss_decay": {
+            "$ref": "#/components/schemas/DecayParamsExpression"
+          }
+        }
       },
       "SampleQuery": {
         "type": "object",
@@ -14240,6 +16535,96 @@
         "enum": [
           "random"
         ]
+      },
+      "RelevanceFeedbackQuery": {
+        "type": "object",
+        "required": [
+          "relevance_feedback"
+        ],
+        "properties": {
+          "relevance_feedback": {
+            "$ref": "#/components/schemas/RelevanceFeedbackInput"
+          }
+        }
+      },
+      "RelevanceFeedbackInput": {
+        "type": "object",
+        "required": [
+          "feedback",
+          "strategy",
+          "target"
+        ],
+        "properties": {
+          "target": {
+            "$ref": "#/components/schemas/VectorInput"
+          },
+          "feedback": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FeedbackItem"
+            }
+          },
+          "strategy": {
+            "$ref": "#/components/schemas/FeedbackStrategy"
+          }
+        }
+      },
+      "FeedbackItem": {
+        "type": "object",
+        "required": [
+          "example",
+          "score"
+        ],
+        "properties": {
+          "example": {
+            "$ref": "#/components/schemas/VectorInput"
+          },
+          "score": {
+            "type": "number",
+            "format": "float"
+          }
+        }
+      },
+      "FeedbackStrategy": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/NaiveFeedbackStrategy"
+          }
+        ]
+      },
+      "NaiveFeedbackStrategy": {
+        "type": "object",
+        "required": [
+          "naive"
+        ],
+        "properties": {
+          "naive": {
+            "$ref": "#/components/schemas/NaiveFeedbackStrategyParams"
+          }
+        }
+      },
+      "NaiveFeedbackStrategyParams": {
+        "type": "object",
+        "required": [
+          "a",
+          "b",
+          "c"
+        ],
+        "properties": {
+          "a": {
+            "type": "number",
+            "format": "float"
+          },
+          "b": {
+            "type": "number",
+            "format": "float",
+            "minimum": 0
+          },
+          "c": {
+            "type": "number",
+            "format": "float"
+          }
+        }
       },
       "QueryRequestBatch": {
         "type": "object",
@@ -14628,6 +17013,685 @@
             "type": "boolean"
           }
         ]
+      },
+      "Usage": {
+        "description": "Usage of the hardware resources, spent to process the request",
+        "type": "object",
+        "properties": {
+          "hardware": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HardwareUsage"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "inference": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InferenceUsage"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
+      },
+      "InferenceUsage": {
+        "type": "object",
+        "required": [
+          "models"
+        ],
+        "properties": {
+          "models": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ModelUsage"
+            }
+          }
+        }
+      },
+      "ModelUsage": {
+        "type": "object",
+        "required": [
+          "tokens"
+        ],
+        "properties": {
+          "tokens": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        }
+      },
+      "ShardKeysResponse": {
+        "type": "object",
+        "properties": {
+          "shard_keys": {
+            "description": "The existing shard keys. Only available when sharding method is `custom`",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ShardKeyDescription"
+            },
+            "nullable": true
+          }
+        }
+      },
+      "ShardKeyDescription": {
+        "type": "object",
+        "required": [
+          "key"
+        ],
+        "properties": {
+          "key": {
+            "$ref": "#/components/schemas/ShardKey"
+          }
+        }
+      },
+      "OptimizationsResponse": {
+        "description": "Optimizations progress for the collection",
+        "type": "object",
+        "required": [
+          "running",
+          "summary"
+        ],
+        "properties": {
+          "summary": {
+            "$ref": "#/components/schemas/OptimizationsSummary"
+          },
+          "running": {
+            "description": "Currently running optimizations.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Optimization"
+            }
+          },
+          "queued": {
+            "description": "An estimated queue of pending optimizations. Requires `?with=queued`.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PendingOptimization"
+            },
+            "nullable": true
+          },
+          "completed": {
+            "description": "Completed optimizations. Requires `?with=completed`. Limited by `?completed_limit=N`.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Optimization"
+            },
+            "nullable": true
+          },
+          "idle_segments": {
+            "description": "Segments that don't require optimization. Requires `?with=idle_segments`.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptimizationSegmentInfo"
+            },
+            "nullable": true
+          }
+        }
+      },
+      "OptimizationsSummary": {
+        "type": "object",
+        "required": [
+          "idle_segments",
+          "queued_optimizations",
+          "queued_points",
+          "queued_segments"
+        ],
+        "properties": {
+          "queued_optimizations": {
+            "description": "Number of pending optimizations in the queue. Each optimization will take one or more unoptimized segments and produce one optimized segment.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "queued_segments": {
+            "description": "Number of unoptimized segments in the queue.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "queued_points": {
+            "description": "Number of points in unoptimized segments in the queue.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "idle_segments": {
+            "description": "Number of segments that don't require optimization.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          }
+        }
+      },
+      "Optimization": {
+        "type": "object",
+        "required": [
+          "optimizer",
+          "progress",
+          "segments",
+          "status",
+          "uuid"
+        ],
+        "properties": {
+          "uuid": {
+            "description": "Unique identifier of the optimization process.\n\nAfter the optimization is complete, a new segment will be created with this UUID.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "optimizer": {
+            "description": "Name of the optimizer that performed this optimization.",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/TrackerStatus"
+          },
+          "segments": {
+            "description": "Segments being optimized.\n\nAfter the optimization is complete, these segments will be replaced by the new optimized segment.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptimizationSegmentInfo"
+            }
+          },
+          "progress": {
+            "$ref": "#/components/schemas/ProgressTree"
+          }
+        }
+      },
+      "OptimizationSegmentInfo": {
+        "type": "object",
+        "required": [
+          "points_count",
+          "uuid"
+        ],
+        "properties": {
+          "uuid": {
+            "description": "Unique identifier of the segment.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "points_count": {
+            "description": "Number of non-deleted points in the segment.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          }
+        }
+      },
+      "ProgressTree": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "description": "Name of the operation.",
+            "type": "string"
+          },
+          "started_at": {
+            "description": "When the operation started.",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "finished_at": {
+            "description": "When the operation finished.",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "duration_sec": {
+            "description": "For finished operations, how long they took, in seconds.",
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "done": {
+            "description": "Number of completed units of work, if applicable.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "nullable": true
+          },
+          "total": {
+            "description": "Total number of units of work, if applicable and known.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "nullable": true
+          },
+          "children": {
+            "description": "Child operations.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProgressTree"
+            }
+          }
+        }
+      },
+      "PendingOptimization": {
+        "type": "object",
+        "required": [
+          "optimizer",
+          "segments"
+        ],
+        "properties": {
+          "optimizer": {
+            "description": "Name of the optimizer that scheduled this optimization.",
+            "type": "string"
+          },
+          "segments": {
+            "description": "Segments that will be optimized.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptimizationSegmentInfo"
+            }
+          }
+        }
+      },
+      "DistributedTelemetryData": {
+        "type": "object",
+        "required": [
+          "collections"
+        ],
+        "properties": {
+          "collections": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/DistributedCollectionTelemetry"
+            }
+          },
+          "cluster": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DistributedClusterTelemetry"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
+      },
+      "DistributedCollectionTelemetry": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "description": "Collection name",
+            "type": "string"
+          },
+          "shards": {
+            "description": "Shards topology",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DistributedShardTelemetry"
+            },
+            "nullable": true
+          },
+          "reshardings": {
+            "description": "Ongoing resharding operations",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReshardingInfo"
+            },
+            "nullable": true
+          },
+          "shard_transfers": {
+            "description": "Ongoing shard transfers",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ShardTransferInfo"
+            },
+            "nullable": true
+          }
+        }
+      },
+      "DistributedShardTelemetry": {
+        "type": "object",
+        "required": [
+          "id",
+          "replicas"
+        ],
+        "properties": {
+          "id": {
+            "description": "Shard ID",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "key": {
+            "description": "Optional shard key",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKey"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "replicas": {
+            "description": "Replica information",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DistributedReplicaTelemetry"
+            }
+          }
+        }
+      },
+      "DistributedReplicaTelemetry": {
+        "type": "object",
+        "required": [
+          "peer_id",
+          "state"
+        ],
+        "properties": {
+          "peer_id": {
+            "description": "Peer ID hosting this replica",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "state": {
+            "$ref": "#/components/schemas/ReplicaState"
+          },
+          "status": {
+            "description": "Shard status",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardStatus"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "total_optimized_points": {
+            "description": "Total optimized points",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "vectors_size_bytes": {
+            "description": "Estimated vectors size in bytes",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "payloads_size_bytes": {
+            "description": "Estimated payloads size in bytes",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "num_points": {
+            "description": "Approximate number of points",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "num_vectors": {
+            "description": "Approximate number of vectors",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "num_vectors_by_name": {
+            "description": "Approximate number of vectors by name",
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "nullable": true
+          },
+          "shard_cleaning_status": {
+            "description": "Shard cleaning task status. After a resharding, a cleanup task is performed to remove outdated points from this shard.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardCleanStatusTelemetry"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "partial_snapshot": {
+            "description": "Partial snapshot telemetry",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PartialSnapshotTelemetry"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
+      },
+      "DistributedClusterTelemetry": {
+        "type": "object",
+        "required": [
+          "enabled",
+          "peers"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "number_of_peers": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "nullable": true
+          },
+          "peers": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/DistributedPeerInfo"
+            }
+          }
+        }
+      },
+      "DistributedPeerInfo": {
+        "type": "object",
+        "required": [
+          "responsive",
+          "uri"
+        ],
+        "properties": {
+          "uri": {
+            "description": "URI of the peer",
+            "type": "string"
+          },
+          "responsive": {
+            "description": "Whether this peer responded for this request",
+            "type": "boolean"
+          },
+          "details": {
+            "description": "If responsive, these details should be available",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DistributedPeerDetails"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
+      },
+      "DistributedPeerDetails": {
+        "type": "object",
+        "required": [
+          "commit",
+          "consensus_thread_status",
+          "is_voter",
+          "num_pending_operations",
+          "term",
+          "version"
+        ],
+        "properties": {
+          "version": {
+            "description": "Qdrant version",
+            "type": "string"
+          },
+          "role": {
+            "description": "Consensus role for the peer",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StateRole"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "is_voter": {
+            "description": "Whether it can participate in leader elections",
+            "type": "boolean"
+          },
+          "term": {
+            "description": "Election term",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "commit": {
+            "description": "Latest accepted commit",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "num_pending_operations": {
+            "description": "Number of operations pending for being applied",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "consensus_thread_status": {
+            "$ref": "#/components/schemas/ConsensusThreadStatus"
+          }
+        }
+      },
+      "VectorNameConfig": {
+        "description": "Configuration for creating a new named vector.\n\nContains only the immutable properties that define a vector space. Storage type, index, and quantization are determined automatically based on the segment type and can be configured separately later.\n\nExample JSON for a dense vector: ```json { \"dense\": { \"size\": 768, \"distance\": \"Cosine\" } } ```\n\nExample JSON for a sparse vector: ```json { \"sparse\": { \"modifier\": \"Idf\" } } ```",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/DenseVectorNameConfig"
+          },
+          {
+            "$ref": "#/components/schemas/SparseVectorNameConfig"
+          }
+        ]
+      },
+      "DenseVectorNameConfig": {
+        "description": "Wrapper for dense vector creation config.",
+        "type": "object",
+        "required": [
+          "dense"
+        ],
+        "properties": {
+          "dense": {
+            "$ref": "#/components/schemas/DenseVectorConfig"
+          }
+        }
+      },
+      "DenseVectorConfig": {
+        "description": "Configuration for creating a new dense named vector.\n\nOnly includes properties that define the vector space and cannot be changed after creation. Storage type, index type, and quantization are inferred.",
+        "type": "object",
+        "required": [
+          "distance",
+          "size"
+        ],
+        "properties": {
+          "size": {
+            "description": "Dimensionality of the vectors",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "distance": {
+            "$ref": "#/components/schemas/Distance"
+          },
+          "multivector_config": {
+            "description": "Configuration for multi-vector points (e.g., ColBERT)",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MultiVectorConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "datatype": {
+            "description": "Element storage type (Float32, Float16, Uint8)",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VectorStorageDatatype"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
+      },
+      "SparseVectorNameConfig": {
+        "description": "Wrapper for sparse vector creation config.",
+        "type": "object",
+        "required": [
+          "sparse"
+        ],
+        "properties": {
+          "sparse": {
+            "$ref": "#/components/schemas/SparseVectorConfig"
+          }
+        }
+      },
+      "SparseVectorConfig": {
+        "description": "Configuration for creating a new sparse named vector.\n\nOnly includes properties that define the vector space and cannot be changed after creation.",
+        "type": "object",
+        "properties": {
+          "modifier": {
+            "description": "Value modifier for sparse vectors (e.g., IDF)",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Modifier"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "datatype": {
+            "description": "Datatype used to store weights in the index",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VectorStorageDatatype"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
       }
     }
   }

--- a/src/components/Collections/CollectionInfo.jsx
+++ b/src/components/Collections/CollectionInfo.jsx
@@ -92,7 +92,7 @@ export const CollectionInfo = ({ collectionName }) => {
       base0F: infoTheme.base0F,
       comment: infoTheme.base0D,
     }),
-    [infoTheme]
+    [infoTheme],
   );
 
   // Load OpenAPI schemas (deduped fetch, cached as singleton promise)

--- a/src/components/Collections/CollectionInfo.jsx
+++ b/src/components/Collections/CollectionInfo.jsx
@@ -92,7 +92,7 @@ export const CollectionInfo = ({ collectionName }) => {
       base0F: infoTheme.base0F,
       comment: infoTheme.base0D,
     }),
-    [infoTheme],
+    [infoTheme]
   );
 
   // Load OpenAPI schemas (deduped fetch, cached as singleton promise)

--- a/src/components/Collections/CollectionInfo.jsx
+++ b/src/components/Collections/CollectionInfo.jsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect } from 'react';
+import React, { memo, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Card, CardContent, CardHeader, IconButton, Tooltip } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
@@ -10,6 +10,13 @@ import { getSnackbarOptions } from '../Common/utils/snackbarOptions';
 import { bigIntJSON } from '../../common/bigIntJSON';
 import CollectionAliases from './CollectionAliases';
 import JsonViewerCustom from '../Common/JsonViewerCustom';
+import {
+  makeCollectionInfoValueTypes,
+  useOpenApiSchemas,
+  ColorspaceProvider,
+  SchemasProvider,
+} from './CollectionInfoKeyRenderer';
+import { useJsonViewerTheme } from '../../theme/json-viewer-theme';
 
 export const CollectionInfo = ({ collectionName }) => {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
@@ -71,6 +78,27 @@ export const CollectionInfo = ({ collectionName }) => {
       });
   };
 
+  // Compute colorspace here (outside json-viewer tree) where useTheme() resolves correctly.
+  // The json-viewer bundles its own MUI, so useTheme() inside custom value renderers
+  // returns a default theme instead of the project's theme.
+  const { theme: infoTheme } = useJsonViewerTheme('info');
+  const colorspace = useMemo(
+    () => ({
+      base02: infoTheme.base02,
+      base08: infoTheme.base08,
+      base09: infoTheme.base09,
+      base0B: infoTheme.base0B,
+      base0E: infoTheme.base0E,
+      base0F: infoTheme.base0F,
+      comment: infoTheme.base0D,
+    }),
+    [infoTheme]
+  );
+
+  // Load OpenAPI schemas (deduped fetch, cached as singleton promise)
+  const openApiSchemas = useOpenApiSchemas();
+  const valueTypes = useMemo(() => makeCollectionInfoValueTypes(openApiSchemas), [openApiSchemas]);
+
   return (
     <Box display="flex" flexDirection="column" gap={5}>
       <CollectionAliases collectionName={collectionName} />
@@ -108,14 +136,19 @@ export const CollectionInfo = ({ collectionName }) => {
           }
         />
         <CardContent>
-          <JsonViewerCustom
-            theme="info"
-            value={collection}
-            displayDataTypes={false}
-            displayObjectSize={false}
-            rootName={false}
-            enableClipboard={false}
-          />
+          <ColorspaceProvider value={colorspace}>
+            <SchemasProvider value={openApiSchemas}>
+              <JsonViewerCustom
+                theme="info"
+                value={collection}
+                displayDataTypes={false}
+                displayObjectSize={false}
+                rootName={false}
+                enableClipboard={false}
+                valueTypes={valueTypes}
+              />
+            </SchemasProvider>
+          </ColorspaceProvider>
         </CardContent>
       </Card>
 

--- a/src/components/Collections/CollectionInfoKeyRenderer.jsx
+++ b/src/components/Collections/CollectionInfoKeyRenderer.jsx
@@ -1,0 +1,186 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Box, Tooltip } from '@mui/material';
+import { getDescriptionByPath, loadOpenApiSchemas } from './openapi-descriptions';
+
+// Context to pass colorspace from outside the json-viewer tree (where useTheme works)
+// into the custom value renderer (where the json-viewer's bundled MUI shadows the project's theme).
+const ColorspaceContext = createContext(null);
+export const ColorspaceProvider = ColorspaceContext.Provider;
+
+// Context for the OpenAPI schemas object
+const SchemasContext = createContext(null);
+export const SchemasProvider = SchemasContext.Provider;
+
+/**
+ * Hook that loads and returns the OpenAPI schemas object.
+ * The fetch is deduped (singleton promise) so multiple mounts share one request.
+ *
+ * @return {object|null} The components.schemas object, or null while loading
+ */
+export function useOpenApiSchemas() {
+  const [schemas, setSchemas] = useState(null);
+
+  useEffect(() => {
+    loadOpenApiSchemas().then(setSchemas);
+  }, []);
+
+  return schemas;
+}
+
+// --- Value rendering ---
+
+function isPrimitive(value) {
+  return value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+}
+
+// DataBox in @textea/json-viewer is: <Box component="div" sx={{ display: 'inline-block', ...sx }} />
+// eslint-disable-next-line react/prop-types
+const DataBox = (props) => <Box component="div" {...props} sx={{ display: 'inline-block', ...props.sx }} />;
+
+const NativeValueRenderer = ({ value }) => {
+  const colors = useContext(ColorspaceContext);
+  const [showRest, setShowRest] = useState(false);
+  const collapseStringsAfterLength = 50;
+
+  if (value === null) {
+    return (
+      <DataBox
+        sx={{
+          color: colors.base08,
+          fontSize: '0.8rem',
+          backgroundColor: colors.base02,
+          fontWeight: 'bold',
+          borderRadius: '3px',
+          padding: '0.5px 2px',
+        }}
+      >
+        NULL
+      </DataBox>
+    );
+  }
+
+  if (typeof value === 'boolean') {
+    return (
+      <DataBox sx={{ color: colors.base0E }}>
+        <DataBox className="bool-value">{value ? 'true' : 'false'}</DataBox>
+      </DataBox>
+    );
+  }
+
+  if (typeof value === 'string') {
+    const displayValue = showRest ? value : value.slice(0, collapseStringsAfterLength);
+    const hasRest = value.length > collapseStringsAfterLength;
+    return (
+      <DataBox
+        sx={{
+          color: colors.base09,
+          overflowWrap: 'anywhere',
+          cursor: hasRest ? 'pointer' : 'inherit',
+        }}
+        onClick={() => hasRest && setShowRest((v) => !v)}
+      >
+        <DataBox className="string-value">
+          &quot;{displayValue}
+          {hasRest && !showRest && <DataBox sx={{ padding: 0.5 }}>…</DataBox>}
+          &quot;
+        </DataBox>
+      </DataBox>
+    );
+  }
+
+  if (typeof value === 'number') {
+    if (isNaN(value)) {
+      return (
+        <DataBox
+          sx={{
+            color: colors.base08,
+            backgroundColor: colors.base02,
+            fontSize: '0.8rem',
+            fontWeight: 'bold',
+            borderRadius: '3px',
+          }}
+        >
+          NaN
+        </DataBox>
+      );
+    }
+    const isInt = value % 1 === 0;
+    const color = isInt ? colors.base0F : colors.base0B;
+    return (
+      <DataBox sx={{ color }}>
+        <DataBox className={isInt ? 'int-value' : 'float-value'}>{value}</DataBox>
+      </DataBox>
+    );
+  }
+
+  return <DataBox>{String(value)}</DataBox>;
+};
+
+NativeValueRenderer.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+};
+
+const DescriptionComment = ({ description, commentColor }) => {
+  // Strip markdown-style links and backticks for the inline preview
+  const clean = description.replace(/\[.*?\]\(.*?\)/g, '').replace(/`/g, '');
+  const firstSentence = clean.split(/\.\s/)[0] + (clean.includes('. ') ? '.' : '');
+  const truncated = firstSentence.length > 60 ? firstSentence.slice(0, 60) + '…' : firstSentence;
+  return (
+    <Tooltip title={description} placement="right" arrow>
+      <Box
+        component="span"
+        sx={{
+          color: commentColor,
+          opacity: 0.4,
+          ml: 3,
+          cursor: 'help',
+        }}
+      >
+        {'// ' + truncated}
+      </Box>
+    </Tooltip>
+  );
+};
+
+DescriptionComment.propTypes = {
+  description: PropTypes.string.isRequired,
+  commentColor: PropTypes.string.isRequired,
+};
+
+const DescriptionValueComponent = ({ value, path }) => {
+  const schemas = useContext(SchemasContext);
+  const colors = useContext(ColorspaceContext);
+  const description = schemas ? getDescriptionByPath(schemas, 'CollectionInfo', path) : null;
+
+  return (
+    <>
+      <NativeValueRenderer value={value} />
+      {description && <DescriptionComment description={description} commentColor={colors.comment} />}
+    </>
+  );
+};
+
+DescriptionValueComponent.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  path: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
+};
+
+/**
+ * Build valueTypes that match primitives when OpenAPI schemas are loaded.
+ *
+ * @param {object|null} openApiSchemas - The loaded schemas object (null disables matching)
+ * @return {Array} valueTypes array for @textea/json-viewer
+ */
+export function makeCollectionInfoValueTypes(openApiSchemas) {
+  if (!openApiSchemas) return [];
+  return [
+    {
+      is: (value, path) => {
+        if (!isPrimitive(value)) return false;
+        return getDescriptionByPath(openApiSchemas, 'CollectionInfo', path) !== null;
+      },
+      Component: DescriptionValueComponent,
+    },
+  ];
+}

--- a/src/components/Collections/CollectionInfoKeyRenderer.jsx
+++ b/src/components/Collections/CollectionInfoKeyRenderer.jsx
@@ -118,7 +118,7 @@ const NativeValueRenderer = ({ value }) => {
 };
 
 NativeValueRenderer.propTypes = {
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool, PropTypes.oneOf([null])]),
 };
 
 const DescriptionComment = ({ description, commentColor }) => {
@@ -162,7 +162,7 @@ const DescriptionValueComponent = ({ value, path }) => {
 };
 
 DescriptionValueComponent.propTypes = {
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool, PropTypes.oneOf([null])]),
   path: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
 };
 

--- a/src/components/Collections/openapi-descriptions.js
+++ b/src/components/Collections/openapi-descriptions.js
@@ -1,0 +1,133 @@
+/**
+ * Resolve a $ref pointer like "#/components/schemas/Foo" to the actual schema object.
+ *
+ * @param {object} schema - A schema that may contain a $ref
+ * @param {object} schemas - All component schemas from the OpenAPI spec
+ * @return {object|null} The resolved schema, or null if unresolvable
+ */
+function resolveRef(schema, schemas) {
+  if (!schema?.$ref) return schema;
+  const name = schema.$ref.replace('#/components/schemas/', '');
+  return schemas[name] ?? null;
+}
+
+/**
+ * Resolve a schema fully: follow $ref, then merge allOf if present.
+ * Returns a flat schema with { properties, description, ... }.
+ *
+ * @param {object} schema - A schema that may contain $ref or allOf
+ * @param {object} schemas - All component schemas
+ * @return {object|null} Resolved schema
+ */
+function resolveSchema(schema, schemas) {
+  if (!schema) return null;
+  const resolved = resolveRef(schema, schemas);
+  if (!resolved) return null;
+
+  if (resolved.allOf) {
+    let mergedProperties = {};
+    let description = resolved.description;
+    for (const sub of resolved.allOf) {
+      const subResolved = resolveSchema(sub, schemas);
+      if (subResolved?.properties) {
+        mergedProperties = { ...mergedProperties, ...subResolved.properties };
+      }
+      if (!description && subResolved?.description) {
+        description = subResolved.description;
+      }
+    }
+    return { ...resolved, properties: mergedProperties, description };
+  }
+
+  return resolved;
+}
+
+/**
+ * Look up a property name in a schema, handling anyOf/oneOf variants
+ * and additionalProperties for dynamic keys.
+ *
+ * @param {object} resolved - A resolved schema object
+ * @param {string} key - The property name to find
+ * @param {object} schemas - All component schemas
+ * @return {object|null} The property schema, or null
+ */
+function findProperty(resolved, key, schemas) {
+  if (!resolved) return null;
+
+  // Direct properties
+  if (resolved.properties?.[key]) {
+    return resolved.properties[key];
+  }
+
+  // anyOf / oneOf — try each variant
+  const variants = resolved.anyOf || resolved.oneOf;
+  if (variants) {
+    for (const variant of variants) {
+      const variantResolved = resolveSchema(variant, schemas);
+      const found = findProperty(variantResolved, key, schemas);
+      if (found) return found;
+    }
+  }
+
+  // additionalProperties — for dynamic keys (named vectors, payload fields, etc.)
+  if (resolved.additionalProperties) {
+    const addPropsSchema = resolveSchema(resolved.additionalProperties, schemas);
+    if (addPropsSchema) return addPropsSchema;
+  }
+
+  return null;
+}
+
+/**
+ * Get the description for a field at the given path within a root schema.
+ *
+ * Follows the JSON path through the OpenAPI schema hierarchy, resolving
+ * $ref pointers, allOf merges, anyOf/oneOf variants, and additionalProperties.
+ *
+ * @param {object} schemas - `spec.components.schemas` from an OpenAPI spec
+ * @param {string} rootSchemaName - Name of the root schema (e.g. "CollectionInfo")
+ * @param {Array<string|number>} path - JSON path segments (e.g. ["config", "hnsw_config", "m"])
+ * @return {string|null} The description string, or null if not found
+ */
+export function getDescriptionByPath(schemas, rootSchemaName, path) {
+  if (!schemas || !rootSchemaName || !path?.length) return null;
+
+  const rootSchema = schemas[rootSchemaName];
+  if (!rootSchema) return null;
+
+  let current = resolveSchema(rootSchema, schemas);
+  let propertySchema = null;
+
+  for (const segment of path) {
+    if (typeof segment !== 'string') return null;
+
+    propertySchema = findProperty(current, segment, schemas);
+    if (!propertySchema) return null;
+
+    // Move into this property for the next segment
+    current = resolveSchema(propertySchema, schemas);
+  }
+
+  // Return the description from the property itself, or from its resolved target
+  return propertySchema?.description || current?.description || null;
+}
+
+// --- Loader (singleton-cached fetch) ---
+
+let descriptionsCache = null;
+
+/**
+ * Fetch openapi.json and return the parsed schemas object.
+ * The fetch is deduped so multiple callers share a single request.
+ *
+ * @return {Promise<object>} The components.schemas object
+ */
+export function loadOpenApiSchemas() {
+  if (!descriptionsCache) {
+    descriptionsCache = fetch(import.meta.env.BASE_URL + './openapi.json')
+      .then((res) => res.json())
+      .then((spec) => spec.components?.schemas ?? {})
+      .catch(() => ({}));
+  }
+  return descriptionsCache;
+}

--- a/src/components/Collections/openapi-descriptions.test.js
+++ b/src/components/Collections/openapi-descriptions.test.js
@@ -1,0 +1,294 @@
+import { describe, expect, it } from 'vitest';
+import { getDescriptionByPath } from './openapi-descriptions';
+
+// Minimal OpenAPI-style schemas that cover all the resolution strategies:
+// $ref, allOf, anyOf, oneOf, additionalProperties, nested properties.
+const schemas = {
+  CollectionInfo: {
+    type: 'object',
+    properties: {
+      status: { $ref: '#/components/schemas/CollectionStatus' },
+      optimizer_status: { $ref: '#/components/schemas/OptimizersStatus' },
+      vectors_count: {
+        description: 'Approximate number of vectors in collection',
+        type: 'integer',
+      },
+      points_count: {
+        description: 'Approximate number of points',
+        type: 'integer',
+      },
+      config: { $ref: '#/components/schemas/CollectionConfig' },
+      payload_schema: {
+        description: 'Types of stored payload',
+        type: 'object',
+        additionalProperties: { $ref: '#/components/schemas/PayloadIndexInfo' },
+      },
+    },
+  },
+
+  CollectionStatus: {
+    description: 'Green = all good, Yellow = optimization running',
+    type: 'string',
+    enum: ['green', 'yellow', 'grey', 'red'],
+  },
+
+  OptimizersStatus: {
+    description: 'Current state of the optimizer',
+    oneOf: [
+      { type: 'string', enum: ['ok'] },
+      {
+        type: 'object',
+        properties: {
+          error: { description: 'Error message from optimizer', type: 'string' },
+        },
+      },
+    ],
+  },
+
+  CollectionConfig: {
+    description: 'Collection configuration',
+    type: 'object',
+    properties: {
+      params: { $ref: '#/components/schemas/CollectionParams' },
+      hnsw_config: { $ref: '#/components/schemas/HnswConfig' },
+      optimizer_config: { $ref: '#/components/schemas/OptimizersConfig' },
+      wal_config: { $ref: '#/components/schemas/WalConfig' },
+    },
+  },
+
+  CollectionParams: {
+    type: 'object',
+    properties: {
+      vectors: { $ref: '#/components/schemas/VectorsConfig' },
+      shard_number: { description: 'Number of shards', type: 'integer' },
+      replication_factor: { description: 'Number of replicas for each shard', type: 'integer' },
+    },
+  },
+
+  // anyOf: single vector mode or named-vectors map
+  VectorsConfig: {
+    description: 'Vector params for single and multiple vector modes',
+    anyOf: [
+      { $ref: '#/components/schemas/VectorParams' },
+      {
+        type: 'object',
+        additionalProperties: { $ref: '#/components/schemas/VectorParams' },
+      },
+    ],
+  },
+
+  VectorParams: {
+    description: 'Params of single vector data storage',
+    type: 'object',
+    properties: {
+      size: { description: 'Dimensionality of vectors', type: 'integer' },
+      distance: { $ref: '#/components/schemas/Distance' },
+      on_disk: { description: 'Store vectors on disk', type: 'boolean' },
+    },
+  },
+
+  Distance: {
+    description: 'Distance metric: Cosine, Euclid, Dot, or Manhattan',
+    type: 'string',
+    enum: ['Cosine', 'Euclid', 'Dot', 'Manhattan'],
+  },
+
+  HnswConfig: {
+    type: 'object',
+    properties: {
+      m: { description: 'Edges per node in HNSW graph', type: 'integer' },
+      ef_construct: { description: 'Neighbours during index building', type: 'integer' },
+    },
+  },
+
+  OptimizersConfig: {
+    type: 'object',
+    properties: {
+      deleted_threshold: { description: 'Min fraction of deleted vectors to optimize', type: 'number' },
+      flush_interval_sec: { description: 'Minimum flush interval', type: 'integer' },
+    },
+  },
+
+  WalConfig: {
+    type: 'object',
+    properties: {
+      wal_capacity_mb: { description: 'WAL segment capacity in MB', type: 'integer' },
+    },
+  },
+
+  PayloadIndexInfo: {
+    description: 'Payload field index info',
+    type: 'object',
+    properties: {
+      data_type: { description: 'Type of the payload field', type: 'string' },
+      points: { description: 'Number of indexed points', type: 'integer' },
+    },
+  },
+
+  // Schema using allOf to test merging
+  ExtendedConfig: {
+    allOf: [
+      { $ref: '#/components/schemas/HnswConfig' },
+      {
+        type: 'object',
+        properties: {
+          extra_param: { description: 'An extra parameter', type: 'string' },
+        },
+      },
+    ],
+  },
+};
+
+describe('getDescriptionByPath', () => {
+  describe('top-level fields', () => {
+    it('returns description for a direct property', () => {
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['vectors_count'])).toBe(
+        'Approximate number of vectors in collection'
+      );
+    });
+
+    it('returns description for another direct property', () => {
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['points_count'])).toBe(
+        'Approximate number of points'
+      );
+    });
+
+    it('returns description for a property with additionalProperties', () => {
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['payload_schema'])).toBe(
+        'Types of stored payload'
+      );
+    });
+  });
+
+  describe('$ref resolution', () => {
+    it('resolves $ref to an enum schema and returns its description', () => {
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['status'])).toBe(
+        'Green = all good, Yellow = optimization running'
+      );
+    });
+
+    it('resolves $ref to a oneOf schema and returns its description', () => {
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['optimizer_status'])).toBe(
+        'Current state of the optimizer'
+      );
+    });
+
+    it('resolves $ref for a nested object and returns its description', () => {
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config'])).toBe(
+        'Collection configuration'
+      );
+    });
+  });
+
+  describe('nested paths through $ref', () => {
+    it('follows config -> hnsw_config -> m', () => {
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'hnsw_config', 'm'])).toBe(
+        'Edges per node in HNSW graph'
+      );
+    });
+
+    it('follows config -> optimizer_config -> deleted_threshold', () => {
+      expect(
+        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'optimizer_config', 'deleted_threshold'])
+      ).toBe('Min fraction of deleted vectors to optimize');
+    });
+
+    it('follows config -> wal_config -> wal_capacity_mb', () => {
+      expect(
+        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'wal_config', 'wal_capacity_mb'])
+      ).toBe('WAL segment capacity in MB');
+    });
+
+    it('follows config -> params -> shard_number', () => {
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'shard_number'])).toBe(
+        'Number of shards'
+      );
+    });
+  });
+
+  describe('anyOf resolution', () => {
+    it('resolves through anyOf to find VectorParams.size', () => {
+      expect(
+        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'size'])
+      ).toBe('Dimensionality of vectors');
+    });
+
+    it('resolves through anyOf to find VectorParams.distance ($ref to enum)', () => {
+      expect(
+        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'distance'])
+      ).toBe('Distance metric: Cosine, Euclid, Dot, or Manhattan');
+    });
+
+    it('resolves through anyOf to find VectorParams.on_disk', () => {
+      expect(
+        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'on_disk'])
+      ).toBe('Store vectors on disk');
+    });
+  });
+
+  describe('oneOf resolution', () => {
+    it('resolves through oneOf to find error field', () => {
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['optimizer_status', 'error'])).toBe(
+        'Error message from optimizer'
+      );
+    });
+  });
+
+  describe('additionalProperties resolution', () => {
+    it('resolves dynamic payload field keys via additionalProperties', () => {
+      expect(
+        getDescriptionByPath(schemas, 'CollectionInfo', ['payload_schema', 'my_field', 'data_type'])
+      ).toBe('Type of the payload field');
+    });
+
+    it('resolves named vector keys via anyOf + additionalProperties', () => {
+      expect(
+        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'my_vector', 'size'])
+      ).toBe('Dimensionality of vectors');
+    });
+  });
+
+  describe('allOf merging', () => {
+    it('finds properties from the base schema in allOf', () => {
+      expect(getDescriptionByPath(schemas, 'ExtendedConfig', ['m'])).toBe(
+        'Edges per node in HNSW graph'
+      );
+    });
+
+    it('finds properties from the extension schema in allOf', () => {
+      expect(getDescriptionByPath(schemas, 'ExtendedConfig', ['extra_param'])).toBe(
+        'An extra parameter'
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns null for empty path', () => {
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', [])).toBeNull();
+    });
+
+    it('returns null for non-existent field', () => {
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['nonexistent'])).toBeNull();
+    });
+
+    it('returns null for non-existent nested field', () => {
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'nonexistent'])).toBeNull();
+    });
+
+    it('returns null for non-existent root schema', () => {
+      expect(getDescriptionByPath(schemas, 'NonExistent', ['foo'])).toBeNull();
+    });
+
+    it('returns null for null schemas', () => {
+      expect(getDescriptionByPath(null, 'CollectionInfo', ['status'])).toBeNull();
+    });
+
+    it('returns null for null path', () => {
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', null)).toBeNull();
+    });
+
+    it('returns null for numeric path segment', () => {
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', [0])).toBeNull();
+    });
+  });
+});

--- a/src/components/Collections/openapi-descriptions.test.js
+++ b/src/components/Collections/openapi-descriptions.test.js
@@ -143,7 +143,7 @@ describe('getDescriptionByPath', () => {
   describe('top-level fields', () => {
     it('returns description for a direct property', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['vectors_count'])).toBe(
-        'Approximate number of vectors in collection',
+        'Approximate number of vectors in collection'
       );
     });
 
@@ -159,13 +159,13 @@ describe('getDescriptionByPath', () => {
   describe('$ref resolution', () => {
     it('resolves $ref to an enum schema and returns its description', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['status'])).toBe(
-        'Green = all good, Yellow = optimization running',
+        'Green = all good, Yellow = optimization running'
       );
     });
 
     it('resolves $ref to a oneOf schema and returns its description', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['optimizer_status'])).toBe(
-        'Current state of the optimizer',
+        'Current state of the optimizer'
       );
     });
 
@@ -177,25 +177,25 @@ describe('getDescriptionByPath', () => {
   describe('nested paths through $ref', () => {
     it('follows config -> hnsw_config -> m', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'hnsw_config', 'm'])).toBe(
-        'Edges per node in HNSW graph',
+        'Edges per node in HNSW graph'
       );
     });
 
     it('follows config -> optimizer_config -> deleted_threshold', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'optimizer_config', 'deleted_threshold'])).toBe(
-        'Min fraction of deleted vectors to optimize',
+        'Min fraction of deleted vectors to optimize'
       );
     });
 
     it('follows config -> wal_config -> wal_capacity_mb', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'wal_config', 'wal_capacity_mb'])).toBe(
-        'WAL segment capacity in MB',
+        'WAL segment capacity in MB'
       );
     });
 
     it('follows config -> params -> shard_number', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'shard_number'])).toBe(
-        'Number of shards',
+        'Number of shards'
       );
     });
   });
@@ -203,19 +203,19 @@ describe('getDescriptionByPath', () => {
   describe('anyOf resolution', () => {
     it('resolves through anyOf to find VectorParams.size', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'size'])).toBe(
-        'Dimensionality of vectors',
+        'Dimensionality of vectors'
       );
     });
 
     it('resolves through anyOf to find VectorParams.distance ($ref to enum)', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'distance'])).toBe(
-        'Distance metric: Cosine, Euclid, Dot, or Manhattan',
+        'Distance metric: Cosine, Euclid, Dot, or Manhattan'
       );
     });
 
     it('resolves through anyOf to find VectorParams.on_disk', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'on_disk'])).toBe(
-        'Store vectors on disk',
+        'Store vectors on disk'
       );
     });
   });
@@ -223,7 +223,7 @@ describe('getDescriptionByPath', () => {
   describe('oneOf resolution', () => {
     it('resolves through oneOf to find error field', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['optimizer_status', 'error'])).toBe(
-        'Error message from optimizer',
+        'Error message from optimizer'
       );
     });
   });
@@ -231,13 +231,13 @@ describe('getDescriptionByPath', () => {
   describe('additionalProperties resolution', () => {
     it('resolves dynamic payload field keys via additionalProperties', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['payload_schema', 'my_field', 'data_type'])).toBe(
-        'Type of the payload field',
+        'Type of the payload field'
       );
     });
 
     it('resolves named vector keys via anyOf + additionalProperties', () => {
       expect(
-        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'my_vector', 'size']),
+        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'my_vector', 'size'])
       ).toBe('Dimensionality of vectors');
     });
   });

--- a/src/components/Collections/openapi-descriptions.test.js
+++ b/src/components/Collections/openapi-descriptions.test.js
@@ -143,122 +143,112 @@ describe('getDescriptionByPath', () => {
   describe('top-level fields', () => {
     it('returns description for a direct property', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['vectors_count'])).toBe(
-        'Approximate number of vectors in collection'
+        'Approximate number of vectors in collection',
       );
     });
 
     it('returns description for another direct property', () => {
-      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['points_count'])).toBe(
-        'Approximate number of points'
-      );
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['points_count'])).toBe('Approximate number of points');
     });
 
     it('returns description for a property with additionalProperties', () => {
-      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['payload_schema'])).toBe(
-        'Types of stored payload'
-      );
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['payload_schema'])).toBe('Types of stored payload');
     });
   });
 
   describe('$ref resolution', () => {
     it('resolves $ref to an enum schema and returns its description', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['status'])).toBe(
-        'Green = all good, Yellow = optimization running'
+        'Green = all good, Yellow = optimization running',
       );
     });
 
     it('resolves $ref to a oneOf schema and returns its description', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['optimizer_status'])).toBe(
-        'Current state of the optimizer'
+        'Current state of the optimizer',
       );
     });
 
     it('resolves $ref for a nested object and returns its description', () => {
-      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config'])).toBe(
-        'Collection configuration'
-      );
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config'])).toBe('Collection configuration');
     });
   });
 
   describe('nested paths through $ref', () => {
     it('follows config -> hnsw_config -> m', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'hnsw_config', 'm'])).toBe(
-        'Edges per node in HNSW graph'
+        'Edges per node in HNSW graph',
       );
     });
 
     it('follows config -> optimizer_config -> deleted_threshold', () => {
-      expect(
-        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'optimizer_config', 'deleted_threshold'])
-      ).toBe('Min fraction of deleted vectors to optimize');
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'optimizer_config', 'deleted_threshold'])).toBe(
+        'Min fraction of deleted vectors to optimize',
+      );
     });
 
     it('follows config -> wal_config -> wal_capacity_mb', () => {
-      expect(
-        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'wal_config', 'wal_capacity_mb'])
-      ).toBe('WAL segment capacity in MB');
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'wal_config', 'wal_capacity_mb'])).toBe(
+        'WAL segment capacity in MB',
+      );
     });
 
     it('follows config -> params -> shard_number', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'shard_number'])).toBe(
-        'Number of shards'
+        'Number of shards',
       );
     });
   });
 
   describe('anyOf resolution', () => {
     it('resolves through anyOf to find VectorParams.size', () => {
-      expect(
-        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'size'])
-      ).toBe('Dimensionality of vectors');
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'size'])).toBe(
+        'Dimensionality of vectors',
+      );
     });
 
     it('resolves through anyOf to find VectorParams.distance ($ref to enum)', () => {
-      expect(
-        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'distance'])
-      ).toBe('Distance metric: Cosine, Euclid, Dot, or Manhattan');
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'distance'])).toBe(
+        'Distance metric: Cosine, Euclid, Dot, or Manhattan',
+      );
     });
 
     it('resolves through anyOf to find VectorParams.on_disk', () => {
-      expect(
-        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'on_disk'])
-      ).toBe('Store vectors on disk');
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'on_disk'])).toBe(
+        'Store vectors on disk',
+      );
     });
   });
 
   describe('oneOf resolution', () => {
     it('resolves through oneOf to find error field', () => {
       expect(getDescriptionByPath(schemas, 'CollectionInfo', ['optimizer_status', 'error'])).toBe(
-        'Error message from optimizer'
+        'Error message from optimizer',
       );
     });
   });
 
   describe('additionalProperties resolution', () => {
     it('resolves dynamic payload field keys via additionalProperties', () => {
-      expect(
-        getDescriptionByPath(schemas, 'CollectionInfo', ['payload_schema', 'my_field', 'data_type'])
-      ).toBe('Type of the payload field');
+      expect(getDescriptionByPath(schemas, 'CollectionInfo', ['payload_schema', 'my_field', 'data_type'])).toBe(
+        'Type of the payload field',
+      );
     });
 
     it('resolves named vector keys via anyOf + additionalProperties', () => {
       expect(
-        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'my_vector', 'size'])
+        getDescriptionByPath(schemas, 'CollectionInfo', ['config', 'params', 'vectors', 'my_vector', 'size']),
       ).toBe('Dimensionality of vectors');
     });
   });
 
   describe('allOf merging', () => {
     it('finds properties from the base schema in allOf', () => {
-      expect(getDescriptionByPath(schemas, 'ExtendedConfig', ['m'])).toBe(
-        'Edges per node in HNSW graph'
-      );
+      expect(getDescriptionByPath(schemas, 'ExtendedConfig', ['m'])).toBe('Edges per node in HNSW graph');
     });
 
     it('finds properties from the extension schema in allOf', () => {
-      expect(getDescriptionByPath(schemas, 'ExtendedConfig', ['extra_param'])).toBe(
-        'An extra parameter'
-      );
+      expect(getDescriptionByPath(schemas, 'ExtendedConfig', ['extra_param'])).toBe('An extra parameter');
     });
   });
 


### PR DESCRIPTION

<img width="939" height="927" alt="image" src="https://github.com/user-attachments/assets/9183bbb5-9e59-4f09-a916-2fe5e58911eb" />



## Summary
- Annotate primitive values in the Collection Info JSON viewer with descriptions loaded dynamically from the OpenAPI spec (`openapi.json`)
- Descriptions appear as inline `// comments` next to each value, with full text in a tooltip on hover
- A new `getDescriptionByPath()` utility resolves descriptions by walking the OpenAPI schema hierarchy, handling `$ref`, `allOf`, `anyOf`/`oneOf`, and `additionalProperties`

## Details

### New files
- **`openapi-descriptions.js`** — Pure utility with `getDescriptionByPath(schemas, rootSchemaName, path)` that follows the exact JSON path through the OpenAPI schema to find the field description
- **`openapi-descriptions.test.js`** — 25 tests covering: direct properties, `$ref` to enums, nested paths through multiple `$ref`s, `anyOf` (VectorsConfig), `oneOf` (OptimizersStatus), `additionalProperties` (named vectors, payload fields), `allOf` merging, and edge cases
- **`CollectionInfoKeyRenderer.jsx`** — Custom `valueTypes` for `@textea/json-viewer` that appends description comments after values, with correct colorspace handling

### Notes
- Descriptions are fetched once from `openapi.json` (singleton-cached promise shared across mounts)
- Colorspace is passed via React context from `CollectionInfo` (outside the json-viewer tree) to work around the json-viewer's bundled MUI shadowing the project's custom theme
- No hardcoded descriptions — if new fields are added to the OpenAPI spec, they get comments automatically

## Test plan
- [x] `npx vitest run src/components/Collections/openapi-descriptions.test.js` — 25 tests pass
- [ ] Verify collection info panel shows inline comments for fields like `points_count`, `segments_count`, `m`, `ef_construct`, etc.
- [ ] Verify comments appear after values (not before)
- [ ] Verify value colors match the original rendering in both light and dark themes
- [ ] Verify tooltip shows full description on hover
- [ ] Verify fields without descriptions in the OpenAPI spec render normally (no comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)