### PR TITLE
Use server-side time for search quality latency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,6 @@
     "node_modules/@babel/core": {
       "version": "7.28.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -386,7 +385,6 @@
     "node_modules/@emotion/react": {
       "version": "11.14.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -424,7 +422,6 @@
     "node_modules/@emotion/styled": {
       "version": "11.14.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1168,7 +1165,6 @@
     "node_modules/@mui/icons-material": {
       "version": "7.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6"
       },
@@ -1193,7 +1189,6 @@
     "node_modules/@mui/material": {
       "version": "7.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6",
         "@mui/core-downloads-tracker": "^7.2.0",
@@ -1298,7 +1293,6 @@
     "node_modules/@mui/system": {
       "version": "7.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6",
         "@mui/private-theming": "^7.2.0",
@@ -3183,7 +3177,6 @@
     "node_modules/@types/react": {
       "version": "18.3.23",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3294,7 +3287,6 @@
     "node_modules/@uppy/core": {
       "version": "4.4.7",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@transloadit/prettier-bytes": "^0.3.4",
         "@uppy/store-default": "^4.2.0",
@@ -3309,7 +3301,6 @@
     "node_modules/@uppy/dashboard": {
       "version": "4.3.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@transloadit/prettier-bytes": "^0.3.4",
         "@uppy/informer": "^4.2.1",
@@ -3331,7 +3322,6 @@
     "node_modules/@uppy/drag-drop": {
       "version": "4.1.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@uppy/utils": "^6.1.4",
         "preact": "^10.5.13"
@@ -3354,7 +3344,6 @@
     "node_modules/@uppy/progress-bar": {
       "version": "4.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@uppy/utils": "^6.1.1",
         "preact": "^10.5.13"
@@ -3610,7 +3599,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3855,7 +3843,6 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -3938,7 +3925,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -4286,8 +4272,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -4405,7 +4390,6 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4996,7 +4980,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5421,9 +5404,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -6573,7 +6556,6 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -6585,7 +6567,6 @@
       "version": "22.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "cssstyle": "^3.0.0",
@@ -7027,7 +7008,6 @@
     "node_modules/lucide-react": {
       "version": "0.545.0",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -7928,8 +7908,7 @@
     },
     "node_modules/monaco-editor": {
       "version": "0.44.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -8529,7 +8508,6 @@
     "node_modules/prop-types": {
       "version": "15.8.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -8602,7 +8580,6 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8644,7 +8621,6 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8892,7 +8868,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9998,7 +9973,6 @@
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/src/components/Collections/SearchQuality/check-index-precision.js
+++ b/src/components/Collections/SearchQuality/check-index-precision.js
@@ -12,9 +12,8 @@ export const checkIndexPrecision = async (
   timeout = 20
 ) => {
   try {
-    const exactSearchtartTime = new Date().getTime();
-
-    const exact = await client.query(collectionName, {
+    const exact = await client.api().queryPoints({
+      collection_name: collectionName,
       limit: limit,
       with_payload: false,
       with_vectors: false,
@@ -27,11 +26,10 @@ export const checkIndexPrecision = async (
       timeout,
     });
 
-    const exactSearchElapsed = new Date().getTime() - exactSearchtartTime;
+    const exactSearchElapsed = Math.round(exact.data.time * 1000);
 
-    const searchStartTime = new Date().getTime();
-
-    const hnsw = await client.query(collectionName, {
+    const hnsw = await client.api().queryPoints({
+      collection_name: collectionName,
       timeout,
       limit: limit,
       with_payload: false,
@@ -42,10 +40,10 @@ export const checkIndexPrecision = async (
       using: vectorName,
     });
 
-    const searchElapsed = new Date().getTime() - searchStartTime;
+    const searchElapsed = Math.round(hnsw.data.time * 1000);
 
-    const exactIds = exact.points.map((item) => item.id);
-    const hnswIds = hnsw.points.map((item) => item.id);
+    const exactIds = exact.data.result.points.map((item) => item.id);
+    const hnswIds = hnsw.data.result.points.map((item) => item.id);
 
     const precision = exactIds.filter((id) => hnswIds.includes(id)).length / exactIds.length;
 

--- a/src/components/Collections/SearchQuality/searchQualityPannel.test.jsx
+++ b/src/components/Collections/SearchQuality/searchQualityPannel.test.jsx
@@ -35,10 +35,13 @@ const VECTORS_NAMED = {
 
 describe('SearchQualityPannel', () => {
   beforeEach(() => {
+    const mockQueryPoints = vi.fn().mockResolvedValue({
+      data: { result: { points: [{ id: 1 }, { id: 2 }] }, status: 'ok', time: 0.005 },
+    });
     useClient.mockReturnValue({
       client: {
         scroll: vi.fn().mockResolvedValue({ points: [{ id: 1 }, { id: 2 }] }),
-        query: vi.fn().mockResolvedValue({ points: [{ id: 1 }, { id: 2 }] }),
+        api: vi.fn().mockReturnValue({ queryPoints: mockQueryPoints }),
       },
     });
   });
@@ -77,7 +80,7 @@ describe('SearchQualityPannel', () => {
     fireEvent.click(button);
     await waitFor(() => {
       expect(useClient().client.scroll).toHaveBeenCalled();
-      expect(useClient().client.query).toHaveBeenCalled();
+      expect(useClient().client.api).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Problem

The Search Quality tab was measuring latency using wall-clock time (`Date.getTime()`), which included network round-trip overhead. This is misleading because:

- Users of the web UI dashboard are almost always geographically far from their Qdrant server, so network latency dominates
- The same query can show 250ms+ in the dashboard while the server-reported time is <10ms

## Solution

Switched to `client.api().queryPoints()` (same HTTP endpoint as `client.query()`) to access the full API response, which includes the server-reported `time` field. Server time (in seconds) is multiplied by 1000 and rounded to get milliseconds.

## Changes

- `check-index-precision.js`: use `response.data.time` instead of wall-clock delta
- `searchQualityPannel.test.jsx`: updated mock to match new response shape

## Test plan

- [x] Run Search Quality check on a collection and verify logged latency matches the `time` field in raw API responses
- [ ] Existing tests pass (pre-existing `should toggle advanced mode` failure is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)