### PR TITLE
VisualizeChart: fix 'Occured' -> 'Occurred' in snackbar error

### DIFF
--- a/src/components/VisualizeChart/index.jsx
+++ b/src/components/VisualizeChart/index.jsx
@@ -239,7 +239,7 @@ const VisualizeChart = ({
 
         myChart.update();
       } else {
-        enqueueSnackbar(`Visualization Unsuccessful, error: Unexpected Error Occured`, { variant: 'error' });
+        enqueueSnackbar(`Visualization Unsuccessful, error: Unexpected Error Occurred`, { variant: 'error' });
       }
     };
 


### PR DESCRIPTION
`enqueueSnackbar` call in `src/components/VisualizeChart/index.jsx:242` read `Visualization Unsuccessful, error: Unexpected Error Occured`. User-visible in the Qdrant dashboard visualization panel. String-literal-only change.