### PR TITLE
Search Quality tab -> ANN Recall + fixes

### DIFF
--- a/src/components/Collections/SearchQuality/SearchQualityPanel.jsx
+++ b/src/components/Collections/SearchQuality/SearchQualityPanel.jsx
@@ -179,7 +179,6 @@ const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo,
     const recalls = [];
     try {
       const sampleResult = await client.scroll(collectionName, {
-        filter: filter,
         with_payload: false,
         with_vector: false,
         limit: SAMPLE_SIZE,

--- a/src/components/Collections/SearchQuality/SearchQualityPanel.jsx
+++ b/src/components/Collections/SearchQuality/SearchQualityPanel.jsx
@@ -19,16 +19,16 @@ import { CopyButton } from '../../Common/CopyButton';
 import { bigIntJSON } from '../../../common/bigIntJSON';
 import Typography from '@mui/material/Typography';
 import { SearchCheck } from 'lucide-react';
-import { checkIndexPrecision } from './check-index-precision';
+import { checkIndexRecall } from './check-index-precision';
 import { useClient } from '../../../context/client-context';
 import CodeEditorWindow from '../../FilterEditorWindow';
 
-const VectorTableRow = ({ vectorObj, name, onCheckIndexQuality, precision, isInProgress }) => {
+const VectorTableRow = ({ vectorObj, name, onCheckIndexQuality, recall, isInProgress, isDisabled }) => {
   return (
     <TableRow data-testid="vector-row">
       <TableCell>
         <Typography variant="subtitle1" component={'span'} color="text.secondary">
-          {name == '' ? '—' : name}
+          {name == '' ? 'Default vector' : name}
         </Typography>
       </TableCell>
       <TableCell>
@@ -46,7 +46,7 @@ const VectorTableRow = ({ vectorObj, name, onCheckIndexQuality, precision, isInP
         {!isInProgress && (
           <Box display="flex" alignItems="center" gap={1.5}>
             <Typography variant="subtitle1" component={'span'} color="text.secondary">
-              {precision ? `${precision * 100}%` : '—'}
+              {recall ? `${(recall * 100).toFixed(2)}%` : '—'}
             </Typography>
             <Button
               variant="contained"
@@ -54,6 +54,7 @@ const VectorTableRow = ({ vectorObj, name, onCheckIndexQuality, precision, isInP
               aria-label="Check index quality"
               data-testid="index-quality-check-button"
               onClick={onCheckIndexQuality}
+              disabled={isDisabled}
               startIcon={<SearchCheck size={18} />}
             >
               Check&nbsp;Index&nbsp;Quality
@@ -69,28 +70,31 @@ VectorTableRow.propTypes = {
   vectorObj: PropTypes.object,
   name: PropTypes.string,
   onCheckIndexQuality: PropTypes.func,
-  precision: PropTypes.number,
+  recall: PropTypes.number,
+  isDisabled: PropTypes.bool,
   isInProgress: PropTypes.bool,
 };
+
+const SAMPLE_SIZE = 100;
 
 const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo, ...other }) => {
   const { client } = useClient();
   const vectorsNames = Object.keys(vectors);
-  const [precision, setPrecision] = useState(() => {
+  const [recall, setRecall] = useState(() => {
     if (vectorsNames) {
-      return vectorsNames.reduce((precision, name) => {
-        precision[name] = null;
-        return precision;
+      return vectorsNames.reduce((recall, name) => {
+        recall[name] = null;
+        return recall;
       }, {});
     }
     return null;
   });
 
   const [advancedMod, setAdvancedMod] = useState(false);
-  const [inProgress, setInProgress] = useState(false);
+  const [inProgressVector, setInProgressVector] = useState(null);
 
   const [code, setCode] = useState(`
-// Run this code to estimate search quality versus exact search
+// Run this code to estimate ANN recall versus exact search
 {
   "limit": 10,
 
@@ -169,27 +173,26 @@ const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo,
   }
 
   const onCheckIndexQuality = async ({ using = '', limit = 10, params = null, filter = null, timeout }) => {
-    setInProgress(true);
+    setInProgressVector(using);
 
     clearLogsFoo && clearLogsFoo();
-    const precisions = [];
+    const recalls = [];
     try {
-      const scrollResult = await client.scroll(collectionName, {
+      const sampleResult = await client.scroll(collectionName, {
+        filter: filter,
         with_payload: false,
         with_vector: false,
-        limit,
+        limit: SAMPLE_SIZE,
       });
 
-      // todo: if exceeded timeout
-
-      const pointIds = scrollResult.points.map((point) => point.id);
+      const pointIds = sampleResult.points.map((point) => point.id);
       const total = pointIds.length;
 
-      loggingFoo && loggingFoo('Starting measuring quality on ' + total + ' requests for ' + using || '---');
+      loggingFoo && loggingFoo(`Starting measuring recall@${limit} on ${total} requests for: ${using || 'Default vector'}`);
 
       for (let idx = 0; idx < total; idx++) {
         const pointId = pointIds[idx];
-        const precision = await checkIndexPrecision(
+        const recall = await checkIndexRecall(
           client,
           collectionName,
           pointId,
@@ -202,31 +205,32 @@ const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo,
           limit,
           timeout
         );
-        if (precision) {
-          precisions.push(precision);
+        if (recall !== null && !isNaN(recall)) {
+          recalls.push(recall);
         }
       }
 
       // Round to 2 decimal places
       const round = (num) => Math.round((num + Number.EPSILON) * 10000) / 10000;
 
-      const avgPrecision = round(precisions.reduce((x, val) => x + val, 0) / precisions.length);
+      const avgRecall = round(recalls.reduce((x, val) => x + val, 0) / recalls.length);
+      // n-1 denominator: Bessel's correction for estimating population std dev from a sample
       const stdDev = round(
-        Math.sqrt(precisions.reduce((x, val) => x + (val - avgPrecision) ** 2, 0) / precisions.length)
+        Math.sqrt(recalls.reduce((x, val) => x + (val - avgRecall) ** 2, 0) / (recalls.length - 1))
       );
 
-      loggingFoo('Mean precision@' + limit + ' for collection: ' + avgPrecision + ' ± ' + stdDev);
+      loggingFoo('Mean recall@' + limit + ' for collection: ' + avgRecall + ' ± ' + stdDev);
 
-      setPrecision((prev) => {
+      setRecall((prev) => {
         return {
           ...prev,
-          [using]: avgPrecision,
+          [using]: avgRecall,
         };
       });
 
-      setInProgress(false);
+      setInProgressVector(null);
     } catch (e) {
-      setInProgress(false);
+      setInProgressVector(null);
       console.error(e);
       loggingFoo && loggingFoo(JSON.stringify(e));
     }
@@ -239,7 +243,7 @@ const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo,
   return (
     <Card elevation={0} data-testid="vectors-info" {...other}>
       <CardHeader
-        title="Search Quality"
+        title="ANN Recall"
         variant="heading"
         sx={{
           flexGrow: 1,
@@ -286,7 +290,7 @@ const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo,
               </TableCell>
               <TableCell sx={{ width: '25%' }}>
                 <Typography variant="subtitle1" fontWeight={600}>
-                  Precision
+                  Recall
                 </Typography>
               </TableCell>
             </TableRow>
@@ -304,9 +308,10 @@ const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo,
                 vectorObj={vectors[vectorName]}
                 name={vectorName}
                 onCheckIndexQuality={() => onCheckIndexQuality({ using: vectorName })}
-                precision={precision ? precision[vectorName] : null}
+                recall={recall ? recall[vectorName] : null}
                 key={vectorName}
-                isInProgress={inProgress}
+                isInProgress={inProgressVector === vectorName}
+                isDisabled={inProgressVector !== null && inProgressVector !== vectorName}
               />
             ))}
           </TableBody>

--- a/src/components/Collections/SearchQuality/SearchQualityPanel.jsx
+++ b/src/components/Collections/SearchQuality/SearchQualityPanel.jsx
@@ -187,7 +187,8 @@ const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo,
       const pointIds = sampleResult.points.map((point) => point.id);
       const total = pointIds.length;
 
-      loggingFoo && loggingFoo(`Starting measuring recall@${limit} on ${total} requests for: ${using || 'Default vector'}`);
+      loggingFoo &&
+        loggingFoo(`Starting measuring recall@${limit} on ${total} requests for: ${using || 'Default vector'}`);
 
       for (let idx = 0; idx < total; idx++) {
         const pointId = pointIds[idx];
@@ -214,9 +215,7 @@ const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo,
 
       const avgRecall = round(recalls.reduce((x, val) => x + val, 0) / recalls.length);
       // n-1 denominator: Bessel's correction for estimating population std dev from a sample
-      const stdDev = round(
-        Math.sqrt(recalls.reduce((x, val) => x + (val - avgRecall) ** 2, 0) / (recalls.length - 1))
-      );
+      const stdDev = round(Math.sqrt(recalls.reduce((x, val) => x + (val - avgRecall) ** 2, 0) / (recalls.length - 1)));
 
       loggingFoo('Mean recall@' + limit + ' for collection: ' + avgRecall + ' ± ' + stdDev);
 

--- a/src/components/Collections/SearchQuality/check-index-precision.js
+++ b/src/components/Collections/SearchQuality/check-index-precision.js
@@ -52,7 +52,9 @@ export const checkIndexRecall = async (
 
     logFoo &&
       logFoo(
-        `Point ${pointId} (${idx + 1}/${total}) recall@${limit}: ${recall} (search time: "exact" ${exactSearchElapsed}ms; "regular" ${searchElapsed}ms)`
+        `Point ${pointId} (${
+          idx + 1
+        }/${total}) recall@${limit}: ${recall} (search time: "exact" ${exactSearchElapsed}ms; "regular" ${searchElapsed}ms)`
       );
 
     return recall;

--- a/src/components/Collections/SearchQuality/check-index-precision.js
+++ b/src/components/Collections/SearchQuality/check-index-precision.js
@@ -1,4 +1,4 @@
-export const checkIndexPrecision = async (
+export const checkIndexRecall = async (
   client,
   collectionName,
   pointId,
@@ -11,6 +11,9 @@ export const checkIndexPrecision = async (
   limit = 10,
   timeout = 20
 ) => {
+  const exclusionFilter = { must_not: [{ has_id: [pointId] }] };
+  const queryFilter = filter ? { must: [filter, exclusionFilter] } : exclusionFilter;
+
   try {
     const exact = await client.api().queryPoints({
       collection_name: collectionName,
@@ -21,7 +24,7 @@ export const checkIndexPrecision = async (
       params: {
         exact: true,
       },
-      filter: filter,
+      filter: queryFilter,
       using: vectorName,
       timeout,
     });
@@ -36,7 +39,7 @@ export const checkIndexPrecision = async (
       with_vectors: false,
       query: pointId,
       params: params,
-      filter: filter,
+      filter: queryFilter,
       using: vectorName,
     });
 
@@ -45,28 +48,14 @@ export const checkIndexPrecision = async (
     const exactIds = exact.data.result.points.map((item) => item.id);
     const hnswIds = hnsw.data.result.points.map((item) => item.id);
 
-    const precision = exactIds.filter((id) => hnswIds.includes(id)).length / exactIds.length;
+    const recall = exactIds.filter((id) => hnswIds.includes(id)).length / exactIds.length;
 
     logFoo &&
       logFoo(
-        'Point ID ' +
-          idx +
-          '(' +
-          idx +
-          '/' +
-          total +
-          ') precision@' +
-          limit +
-          ': ' +
-          precision +
-          ' (search time exact: ' +
-          exactSearchElapsed +
-          'ms, regular: ' +
-          searchElapsed +
-          'ms)'
+        `Point ${pointId} (${idx + 1}/${total}) recall@${limit}: ${recall} (search time: "exact" ${exactSearchElapsed}ms; "regular" ${searchElapsed}ms)`
       );
 
-    return precision;
+    return recall;
   } catch (e) {
     console.error('Error: ', e);
     console.error('Skipping point: ', idx);

--- a/src/components/Collections/SearchQuality/searchQualityPannel.test.jsx
+++ b/src/components/Collections/SearchQuality/searchQualityPannel.test.jsx
@@ -52,7 +52,7 @@ describe('SearchQualityPannel', () => {
         <SearchQualityPanel collectionName={COLLECTION_NAME} vectors={VECTORS} />
       </MemoryRouter>
     );
-    expect(screen.getByText('Search Quality')).toBeInTheDocument();
+    expect(screen.getByText('ANN Recall')).toBeInTheDocument();
     expect(screen.getByText('512')).toBeInTheDocument();
     expect(screen.getByText('Cosine')).toBeInTheDocument();
   });
@@ -63,7 +63,7 @@ describe('SearchQualityPannel', () => {
         <SearchQualityPanel collectionName={COLLECTION_NAME} vectors={VECTORS_NAMED} />
       </MemoryRouter>
     );
-    expect(screen.getByText('Search Quality')).toBeInTheDocument();
+    expect(screen.getByText('ANN Recall')).toBeInTheDocument();
     expect(screen.getByText('text')).toBeInTheDocument();
     expect(screen.getByText('image')).toBeInTheDocument();
     expect(screen.getAllByText('512')).toHaveLength(2);

--- a/src/components/FilterEditorWindow/index.jsx
+++ b/src/components/FilterEditorWindow/index.jsx
@@ -47,7 +47,7 @@ const CodeEditorWindow = ({ onChange, code, onChangeResult, customRequestSchema,
   function onRun(codeText) {
     const data = codeParse(codeText);
     if (data.error) {
-      enqueueSnackbar(`Visualization Unsuccessful, error: ${JSON.stringify(data.error)}`, {
+      enqueueSnackbar(`Invalid JSON: ${JSON.stringify(data.error)}`, {
         variant: 'error',
       });
       return data;

--- a/src/pages/Collection.jsx
+++ b/src/pages/Collection.jsx
@@ -49,7 +49,7 @@ function Collection() {
                 {!isRestricted && <Tab label="Optimizations" value={'optimizations'} />}
                 {!isRestricted && <Tab label="Memory" value={'memory'} />}
                 {!isRestricted && <Tab label="Cluster" value={'cluster'} />}
-                {!isRestricted && <Tab label="Search Quality" value={'quality'} />}
+                {!isRestricted && <Tab label="ANN Recall" value={'quality'} />}
                 {!isRestricted && <Tab label="Snapshots" value={'snapshots'} />}
                 <Tab
                   label="Visualize"


### PR DESCRIPTION
Important for clarity:
- Rename "Search Quality" tab, card title, column header to "ANN Recall." (& rename precision → recall throughout)
- Sample size != top-k retrieved results as it was before; fix at SAMPLE_SIZE = 100 (reasonable default, for now)

Beautifications:
- Exclude query point from both exact and HNSW results to avoid a point being its own nearest neighbor
- Fix std dev: population formula /n → sample formula /n-1 
- Per-vector loading state: only the active row shows the progress bar
- Disable other vector buttons while one measurement is running
- Fix log: show actual scrolled point ID instead of loop index
- Generalize FilterEditorWindow error, previously "Visualization Unsuccessful" was shared across tabs
- Unnamed vector displays as "Default vector" instead of "—"