### PR TITLE
Feature/add subpath routing support

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,16 +3,16 @@
 
 <head>
   <meta charset="utf-8" />
-  <link rel="icon" href="/favicon.ico" />
+  <link rel="icon" href="%BASE_URL%favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Qdrant Web UI" />
-  <link rel="apple-touch-icon" href="/logo192.png" />
+  <link rel="apple-touch-icon" href="%BASE_URL%logo192.png" />
   <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-  <link rel="manifest" href="/manifest.json" />
+  <link rel="manifest" href="%BASE_URL%manifest.json" />
   <!--
       Notice the use of  in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/common/client.js
+++ b/src/common/client.js
@@ -1,5 +1,5 @@
 import { QdrantClient } from '@qdrant/js-client-rest';
-import { getBaseURL } from './utils';
+import { getQdrantPrefix } from './utils';
 
 /**
  * Extended QdrantClient class with additional methods
@@ -8,8 +8,8 @@ import { getBaseURL } from './utils';
  */
 export class QdrantClientExtended extends QdrantClient {
   #downloadController;
-  constructor({ url, apiKey, port }) {
-    super({ url, apiKey, port, checkCompatibility: false, headers: { 'x-inference-proxy': 'true' } });
+  constructor({ url, apiKey, port, prefix = '' }) {
+    super({ url, apiKey, port, prefix, checkCompatibility: false, headers: { 'x-inference-proxy': 'true' } });
 
     this.downloadSnapshot = this.downloadSnapshot.bind(this);
     this.getSnapshotUploadUrl = this.getSnapshotUploadUrl.bind(this);
@@ -19,7 +19,8 @@ export class QdrantClientExtended extends QdrantClient {
     this.url = url;
     this.apiKey = apiKey;
     this.port = port;
-
+    this.prefix = prefix;
+    
     this.#downloadController = new AbortController();
   }
 
@@ -44,7 +45,7 @@ export class QdrantClientExtended extends QdrantClient {
     }
 
     const snapshotUrl = new URL(
-      `/collections/${encodeURIComponent(collectionName)}/snapshots/${encodeURIComponent(snapshotName)}`,
+      `${this.prefix}/collections/${encodeURIComponent(collectionName)}/snapshots/${encodeURIComponent(snapshotName)}`,
       this.url
     ).href;
 
@@ -73,7 +74,7 @@ export class QdrantClientExtended extends QdrantClient {
    * @return {module:url.URL} - URL object for snapshot upload
    */
   getSnapshotUploadUrl(collectionName) {
-    return new URL(`collections/${encodeURIComponent(collectionName)}/snapshots/upload`, this.url);
+    return new URL(`${this.prefix}/collections/${encodeURIComponent(collectionName)}/snapshots/upload`, this.url);
   }
 
   /**
@@ -87,11 +88,13 @@ export class QdrantClientExtended extends QdrantClient {
 
 export default function qdrantClient({ apiKey }) {
   let url;
+  let prefix = ''
   let port = 6333;
   if (process.env.NODE_ENV === 'development') {
     url = 'http://localhost:6333';
   } else {
-    url = getBaseURL();
+    url = window.location.origin;
+    prefix = getQdrantPrefix();
     if (window.location.port) {
       port = window.location.port;
     } else {
@@ -107,6 +110,7 @@ export default function qdrantClient({ apiKey }) {
     url,
     apiKey,
     port,
+    prefix
   };
 
   return new QdrantClientExtended(options);

--- a/src/common/client.test.js
+++ b/src/common/client.test.js
@@ -38,6 +38,24 @@ describe('QdrantClientExtended', () => {
       expect(actualRequest.headers.get('Content-Type')).toBe('application/gzip');
       expect(actualRequest.headers.get('api-key')).toBe(apiKey);
     });
+
+    it('fetch should include prefix in snapshot URL', async () => {
+      const fetch = vi.fn();
+      vi.stubGlobal('fetch', fetch);
+      const fetchSpy = vi.spyOn(global, 'fetch');
+
+      const client = new QdrantClientExtended({
+        url: 'https://example.com',
+        apiKey: 'test-api-key',
+        port: null,
+        prefix: '/qdrantinstance1',
+      });
+
+      await client.downloadSnapshot('demo', 'snapshot-a');
+
+      const [actualRequest] = fetchSpy.mock.calls[0];
+      expect(actualRequest.url).toBe('https://example.com/qdrantinstance1/collections/demo/snapshots/snapshot-a');
+    });
   });
 
   // test for getSnapshotUploadUrl
@@ -52,6 +70,19 @@ describe('QdrantClientExtended', () => {
 
       expect(client.getSnapshotUploadUrl('test').href).toBe(
         new URL('collections/test/snapshots/upload', 'http://localhost').href
+      );
+    });
+
+    it('should return prefixed url when prefix is configured', () => {
+      const client = new QdrantClientExtended({
+        url: 'https://example.com',
+        apiKey: 'test',
+        port: null,
+        prefix: '/qdrantinstance1',
+      });
+
+      expect(client.getSnapshotUploadUrl('test').href).toBe(
+        new URL('/qdrantinstance1/collections/test/snapshots/upload', 'https://example.com').href
       );
     });
   });

--- a/src/common/urils.test.js
+++ b/src/common/urils.test.js
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getBaseURL, pumpFile, updateProgress } from './utils';
+import { getBaseURL, getQdrantPrefix, pumpFile, updateProgress } from './utils';
 
 describe('utils', () => {
   describe('getBaseURL', () => {
@@ -27,6 +27,44 @@ describe('utils', () => {
       const result = 'http://localhost:63342/myapp/';
 
       expect(getBaseURL()).toEqual(result);
+    });
+
+    it('should return base url when pathname has trailing slash after dashboard', () => {
+      const window = {
+        location: {
+          href: 'https://example.com/myapp/dashboard/',
+          origin: 'https://example.com',
+        },
+      };
+      vi.stubGlobal('window', window);
+
+      const result = 'https://example.com/myapp/';
+
+      expect(getBaseURL()).toEqual(result);
+    });
+  });
+
+  describe('getQdrantPrefix', () => {
+    it('should derive prefix from dashboard URL', () => {
+      const window = {
+        location: {
+          href: 'https://example.com/instance1/dashboard',
+        },
+      };
+      vi.stubGlobal('window', window);
+
+      expect(getQdrantPrefix()).toEqual('/instance1');
+    });
+
+    it('should return empty prefix for root dashboard URL', () => {
+      const window = {
+        location: {
+          href: 'https://example.com/dashboard',
+        },
+      };
+      vi.stubGlobal('window', window);
+
+      expect(getQdrantPrefix()).toEqual('');
     });
   });
 

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -1,7 +1,23 @@
-export const getBaseURL = function () {
+const stripDashboardSuffix = (pathname) => {
+  if (!pathname){
+    return '/';
+  }
+
+  const normalized = pathname.replace(/\/+$/, '') || '/';
+  return normalized.replace(/\/dashboard$/, '') || '/';
+};
+
+export const getQdrantPrefix = function () {
   const url = new URL(window.location.href);
-  const pathname = url.pathname.replace(/dashboard$/, '');
-  return new URL(pathname, url.href).href;
+  const prefix = stripDashboardSuffix(url.pathname);
+  return prefix === '/' ? '' : prefix;
+};
+
+export const getBaseURL = function () {
+  const origin = window.location.origin || new URL(window.location.href).origin;
+  const prefix = getQdrantPrefix();
+  const normalizedPrefix = prefix ? `${prefix}/` : '/';
+  return new URL(normalizedPrefix, origin).href;
 };
 
 export const pumpFile = function (reader, callback, chunks = []) {


### PR DESCRIPTION
Resolves #94 

Add zero-config subpath routing support

Updates the web app to support hosting behind reverse proxies on non-root paths (e.g., `example.com/qdrantinstance/dashboard`) without requiring custom rebuilds.

- Changed `QdrantClientExtended` to dynamically detect and extract the API prefix.
- Also added tests for prefix extraction.

