### PR TITLE
Fetch point payload facets lazily instead of on page load

### DIFF
--- a/src/components/Points/PointsFilter/PayloadFilterField.jsx
+++ b/src/components/Points/PointsFilter/PayloadFilterField.jsx
@@ -28,6 +28,7 @@ const PayloadFilterField = memo(function PayloadFilterField({
   payloadSchema,
   payloadKeyOptions,
   payloadValues = {},
+  onRequestFacetValues,
 }) {
   const theme = useTheme();
   const containerRef = useRef(null);
@@ -120,6 +121,15 @@ const PayloadFilterField = memo(function PayloadFilterField({
       .sort(sortByLengthAndAlpha)
       .slice(0, MAX_OPTIONS);
   }, [currentWord, payloadKeyOptions, isTypingValue, currentKey, currentValuePart, payloadValues]);
+
+  // Lazily request facet values once the user starts entering a value for a
+  // field (i.e. has typed "key:"). Facet requests are expensive, so they are
+  // only fired on demand; PointsTabs dedupes and ignores non-keyword fields.
+  useEffect(() => {
+    if (isTypingValue && currentKey && onRequestFacetValues) {
+      onRequestFacetValues(currentKey);
+    }
+  }, [isTypingValue, currentKey, onRequestFacetValues]);
 
   // Auto-show/hide autocomplete based on current word (only when focused)
   useEffect(() => {
@@ -337,6 +347,7 @@ PayloadFilterField.propTypes = {
   payloadSchema: PropTypes.object,
   payloadKeyOptions: PropTypes.array.isRequired,
   payloadValues: PropTypes.object,
+  onRequestFacetValues: PropTypes.func,
 };
 
 export default PayloadFilterField;

--- a/src/components/Points/PointsFilter/PointsFilter.jsx
+++ b/src/components/Points/PointsFilter/PointsFilter.jsx
@@ -12,6 +12,7 @@ const PointsFilter = ({
   onFiltersChange,
   payloadSchema = {},
   payloadValues = {},
+  onRequestFacetValues,
   points,
 }) => {
   const [isSimilarExpanded, setIsSimilarExpanded] = useState(false);
@@ -48,6 +49,7 @@ const PointsFilter = ({
             payloadSchema={payloadSchema}
             payloadKeyOptions={payloadKeyOptions}
             payloadValues={payloadValues}
+            onRequestFacetValues={onRequestFacetValues}
           />
         </Grid>
       </Grid>
@@ -62,6 +64,7 @@ PointsFilter.propTypes = {
   onFiltersChange: PropTypes.func.isRequired,
   payloadSchema: PropTypes.object,
   payloadValues: PropTypes.object,
+  onRequestFacetValues: PropTypes.func,
   points: PropTypes.shape({
     payload_schema: PropTypes.object,
     points: PropTypes.arrayOf(PropTypes.shape({ payload: PropTypes.object })),

--- a/src/components/Points/PointsTabs.jsx
+++ b/src/components/Points/PointsTabs.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import PointCard from './PointCard';
 import PointCardSkeleton from './PointCardSkeleton';
@@ -21,6 +21,9 @@ const PointsTabs = ({ collectionName, client }) => {
   const [payloadSchema, setPayloadSchema] = useState({});
   const [payloadValues, setPayloadValues] = useState({});
   const [requestCount, setRequestCount] = useState(0);
+  // Tracks keyword fields whose facet values have already been requested,
+  // so we don't refire facet requests on every keystroke.
+  const requestedFacetsRef = useRef(new Set());
 
   const onSimilarIdsChange = (ids, vectorName) => {
     if (vectorName !== undefined) {
@@ -63,30 +66,40 @@ const PointsTabs = ({ collectionName, client }) => {
       const collectionInfo = await qdrantClient.getCollection(collectionName);
       const schema = collectionInfo.payload_schema || {};
       setPayloadSchema(schema);
-
-      // Fetch facet values for keyword fields
-      const keywordFields = Object.entries(schema)
-        .filter(([, fieldInfo]) => fieldInfo.data_type === 'keyword')
-        .map(([key]) => key);
-
-      if (keywordFields.length > 0) {
-        const facetPromises = keywordFields.map(async (key) => {
-          try {
-            const hits = await qdrantClient.facet(collectionName, { key, limit: 50 });
-            return [key, hits.hits.map((hit) => hit.value)];
-          } catch {
-            // Silently ignore facet errors (e.g., if facet API is not available)
-            return [key, []];
-          }
-        });
-
-        const facetResults = await Promise.all(facetPromises);
-        const values = Object.fromEntries(facetResults.filter(([, vals]) => vals.length > 0));
-        setPayloadValues(values);
-      }
+      // Reset lazily-loaded facet values when switching collections.
+      setPayloadValues({});
+      requestedFacetsRef.current = new Set();
     };
     getCollection();
   }, [collectionName, qdrantClient]);
+
+  // Lazily fetch facet values for a keyword field, on demand, when the user
+  // references that field in the filter input. Facet requests can be expensive
+  // on large collections, so we never fire them eagerly for the whole schema.
+  const fetchFacetValues = useCallback(
+    async (key) => {
+      if (!key || requestedFacetsRef.current.has(key)) {
+        return;
+      }
+      const fieldInfo = payloadSchema[key];
+      if (!fieldInfo || fieldInfo.data_type !== 'keyword') {
+        return;
+      }
+      requestedFacetsRef.current.add(key);
+      try {
+        const hits = await qdrantClient.facet(collectionName, { key, limit: 50 });
+        const values = hits.hits.map((hit) => hit.value);
+        if (values.length > 0) {
+          setPayloadValues((prev) => ({ ...prev, [key]: values }));
+        }
+      } catch {
+        // Silently ignore facet errors (e.g., if facet API is not available),
+        // and allow a retry on a later keystroke.
+        requestedFacetsRef.current.delete(key);
+      }
+    },
+    [collectionName, qdrantClient, payloadSchema]
+  );
 
   useEffect(() => {
     const getPoints = async () => {
@@ -183,6 +196,7 @@ const PointsTabs = ({ collectionName, client }) => {
           onFiltersChange={onFiltersChange}
           payloadSchema={payloadSchema}
           payloadValues={payloadValues}
+          onRequestFacetValues={fetchFacetValues}
           points={points}
         />
       </Grid>


### PR DESCRIPTION
## Problem

In the Points view, the page eagerly fired one `facet()` request per keyword-indexed field as soon as a collection was opened (`PointsTabs.jsx`'s `getCollection` effect), regardless of whether the user ever touched the filter. On collections with many keyword fields — or where faceting is expensive — this made opening the Points view slow and wasteful.

## Change

Facets are now fetched **lazily, per-field, on demand** — only when the user references a keyword field in the payload filter input (i.e. after typing `key:`).

- `PointsTabs.jsx`: the schema effect no longer fetches facets. Added `fetchFacetValues(key)`, which fetches facets for a single keyword field, dedupes via a `requestedFacetsRef` set (so it doesn't refire on every keystroke), skips non-keyword fields, and allows retry on error. Cached values reset on collection change.
- `PointsFilter.jsx`: forwards the new `onRequestFacetValues` callback.
- `PayloadFilterField.jsx`: requests facet values for the current key once the user starts entering a value (`key:`).

## Result

- Opening the Points view now fires **zero** facet requests.
- At most **one** facet request per keyword field the user actually filters on.
- Value autocomplete behavior is unchanged once values arrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)