### PR TITLE
Use v1.16+ snapshot in tutorial, old snapshot does not work anymore

### DIFF
--- a/src/components/InteractiveTutorial/MdxPages/LoadContent.mdx
+++ b/src/components/InteractiveTutorial/MdxPages/LoadContent.mdx
@@ -12,7 +12,7 @@ The collection will take on the parameters of the snapshot, with vector size of 
 ```json withRunButton=true
 PUT /collections/midjourney/snapshots/recover
 {
-  "location": "http://snapshots.qdrant.io/midlib.snapshot"
+  "location": "http://snapshots.qdrant.io/midlib-v1.16.0.snapshot"
 }
 ```
 


### PR DESCRIPTION
The 'load context' tutorial still listed an old snapshot. Recovering this snapshot fails and may break your cluster.

<img width="3116" height="1824" alt="image" src="https://github.com/user-attachments/assets/02c9f976-144a-4d61-8da0-1ea1220d5608" />

<img width="3116" height="1824" alt="image" src="https://github.com/user-attachments/assets/81858c6a-e2e7-435c-ae6e-d079f16cf51f" />

This updates the snapshot URL to use the v1.16.0+ version instead. The data set page already lists this new version and does not need adjusting.