### PR TITLE
added multi delete feature for collections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -417,6 +418,7 @@
     "node_modules/@emotion/react": {
       "version": "11.14.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -454,6 +456,7 @@
     "node_modules/@emotion/styled": {
       "version": "11.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1207,6 +1210,7 @@
     "node_modules/@mui/icons-material": {
       "version": "7.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6"
       },
@@ -1231,6 +1235,7 @@
     "node_modules/@mui/material": {
       "version": "7.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6",
         "@mui/core-downloads-tracker": "^7.2.0",
@@ -1335,6 +1340,7 @@
     "node_modules/@mui/system": {
       "version": "7.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6",
         "@mui/private-theming": "^7.2.0",
@@ -3280,6 +3286,7 @@
     "node_modules/@types/react": {
       "version": "18.3.23",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3390,6 +3397,7 @@
     "node_modules/@uppy/core": {
       "version": "4.4.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@transloadit/prettier-bytes": "^0.3.4",
         "@uppy/store-default": "^4.2.0",
@@ -3404,6 +3412,7 @@
     "node_modules/@uppy/dashboard": {
       "version": "4.3.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@transloadit/prettier-bytes": "^0.3.4",
         "@uppy/informer": "^4.2.1",
@@ -3425,6 +3434,7 @@
     "node_modules/@uppy/drag-drop": {
       "version": "4.1.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@uppy/utils": "^6.1.4",
         "preact": "^10.5.13"
@@ -3447,6 +3457,7 @@
     "node_modules/@uppy/progress-bar": {
       "version": "4.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@uppy/utils": "^6.1.1",
         "preact": "^10.5.13"
@@ -3716,6 +3727,7 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3963,6 +3975,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
       "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
@@ -4059,6 +4072,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4411,7 +4425,8 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -4529,6 +4544,7 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5125,6 +5141,7 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6713,6 +6730,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -6724,6 +6742,7 @@
       "version": "22.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "cssstyle": "^3.0.0",
@@ -7169,6 +7188,7 @@
     "node_modules/lucide-react": {
       "version": "0.545.0",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -8069,7 +8089,8 @@
     },
     "node_modules/monaco-editor": {
       "version": "0.44.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -8677,6 +8698,7 @@
     "node_modules/prop-types": {
       "version": "15.8.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -8749,6 +8771,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8790,6 +8813,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9037,6 +9061,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9871,9 +9896,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -10153,6 +10178,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/src/components/Collections/CollectionsList.jsx
+++ b/src/components/Collections/CollectionsList.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { MenuItem, TableCell, TableRow, Typography, Table } from '@mui/material';
+import { Checkbox, MenuItem, TableCell, TableRow, Typography, Table } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import {
   StyledTableBody,
@@ -17,12 +17,27 @@ import CollectionStatus from './CollectionStatus';
 import VectorsConfigChips from '../Common/VectorsConfigChips';
 import { CopyableGroupedNumber } from '../Common/CopyableGroupedNumber';
 
-const CollectionTableRow = ({ collection, getCollectionsCall, refreshCollection, isRefreshing }) => {
+const CollectionTableRow = ({
+  collection,
+  getCollectionsCall,
+  refreshCollection,
+  isRefreshing,
+  isSelected,
+  onToggleSelect,
+}) => {
   const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
   const theme = useTheme();
 
   return (
-    <StyledTableRow>
+    <StyledTableRow selected={isSelected}>
+      <TableCell padding="checkbox">
+        <Checkbox
+          checked={isSelected}
+          onChange={() => onToggleSelect(collection.name)}
+          inputProps={{ 'aria-label': `Select collection ${collection.name}` }}
+          size="small"
+        />
+      </TableCell>
       <TableCell>
         <Typography component={StyledLink} to={`/collections/${encodeURIComponent(collection.name)}`}>
           {collection.name}
@@ -82,14 +97,36 @@ CollectionTableRow.propTypes = {
   getCollectionsCall: PropTypes.func.isRequired,
   refreshCollection: PropTypes.func.isRequired,
   isRefreshing: PropTypes.bool.isRequired,
+  isSelected: PropTypes.bool.isRequired,
+  onToggleSelect: PropTypes.func.isRequired,
 };
 
-const CollectionsList = ({ collections, getCollectionsCall, refreshCollection, isRefreshing }) => {
+const CollectionsList = ({
+  collections,
+  getCollectionsCall,
+  refreshCollection,
+  isRefreshing,
+  selectedCollections,
+  handleToggleSelect,
+  handleSelectAll,
+}) => {
+  const allSelected = collections.length > 0 && collections.every((c) => selectedCollections.has(c.name));
+  const someSelected = collections.some((c) => selectedCollections.has(c.name));
+
   return (
     <StyledTableContainer>
       <Table aria-label="simple table">
         <StyledTableHead>
           <TableRow>
+            <StyledHeaderCell padding="checkbox">
+              <Checkbox
+                checked={allSelected}
+                indeterminate={someSelected && !allSelected}
+                onChange={() => handleSelectAll(collections)}
+                inputProps={{ 'aria-label': 'Select all collections on this page' }}
+                size="small"
+              />
+            </StyledHeaderCell>
             <StyledHeaderCell width="25%">Name</StyledHeaderCell>
             <StyledHeaderCell width="12%">Status</StyledHeaderCell>
             <StyledHeaderCell align="center">Points (Approx)</StyledHeaderCell>
@@ -112,6 +149,8 @@ const CollectionsList = ({ collections, getCollectionsCall, refreshCollection, i
                 getCollectionsCall={getCollectionsCall}
                 refreshCollection={refreshCollection}
                 isRefreshing={isRefreshing}
+                isSelected={selectedCollections.has(collection.name)}
+                onToggleSelect={handleToggleSelect}
               />
             ))}
         </StyledTableBody>
@@ -125,6 +164,9 @@ CollectionsList.propTypes = {
   getCollectionsCall: PropTypes.func.isRequired,
   refreshCollection: PropTypes.func.isRequired,
   isRefreshing: PropTypes.bool.isRequired,
+  selectedCollections: PropTypes.instanceOf(Set).isRequired,
+  handleToggleSelect: PropTypes.func.isRequired,
+  handleSelectAll: PropTypes.func.isRequired,
 };
 
 export default CollectionsList;

--- a/src/components/Collections/collectionList.test.jsx
+++ b/src/components/Collections/collectionList.test.jsx
@@ -56,6 +56,12 @@ const COLLECTIONS = [
   },
 ];
 
+const DEFAULT_SELECTION_PROPS = {
+  selectedCollections: new Set(),
+  handleToggleSelect: vi.fn(),
+  handleSelectAll: vi.fn(),
+};
+
 describe('CollectionsList', () => {
   it('should render CollectionsList with given data', () => {
     render(
@@ -65,6 +71,7 @@ describe('CollectionsList', () => {
           getCollectionsCall={() => {}}
           refreshCollection={vi.fn()}
           isRefreshing={false}
+          {...DEFAULT_SELECTION_PROPS}
         />
       </MemoryRouter>
     );
@@ -80,6 +87,7 @@ describe('CollectionsList', () => {
           getCollectionsCall={() => {}}
           refreshCollection={vi.fn()}
           isRefreshing={false}
+          {...DEFAULT_SELECTION_PROPS}
         />
       </MemoryRouter>
     );
@@ -95,6 +103,7 @@ describe('CollectionsList', () => {
     expect(screen.getByText('manhattan')).toBeInTheDocument();
     expect(screen.getByText('Aliases: alias1, alias2')).toBeInTheDocument();
   });
+
   it('should render Refresh menu item in actions menu', () => {
     render(
       <MemoryRouter>
@@ -103,6 +112,7 @@ describe('CollectionsList', () => {
           getCollectionsCall={() => {}}
           refreshCollection={vi.fn()}
           isRefreshing={false}
+          {...DEFAULT_SELECTION_PROPS}
         />
       </MemoryRouter>
     );
@@ -118,6 +128,7 @@ describe('CollectionsList', () => {
           getCollectionsCall={() => {}}
           refreshCollection={mockRefresh}
           isRefreshing={false}
+          {...DEFAULT_SELECTION_PROPS}
         />
       </MemoryRouter>
     );
@@ -134,6 +145,7 @@ describe('CollectionsList', () => {
           getCollectionsCall={() => {}}
           refreshCollection={vi.fn()}
           isRefreshing={true}
+          {...DEFAULT_SELECTION_PROPS}
         />
       </MemoryRouter>
     );

--- a/src/pages/Collections.jsx
+++ b/src/pages/Collections.jsx
@@ -230,7 +230,7 @@ function Collections() {
             </Typography>
           </Grid>
           <Grid
-            sx={{ display: 'flex', justifyContent: { md: 'end' }, gap: 2 }}
+            sx={{ display: 'flex', alignItems: 'center', justifyContent: { md: 'end' }, gap: 2 }}
             size={{
               xs: 12,
               md: 7,
@@ -303,7 +303,13 @@ function Collections() {
         open={openBulkDeleteDialog}
         onClose={() => setOpenBulkDeleteDialog(false)}
         title={`Delete ${selectedCollections.size} collection${selectedCollections.size !== 1 ? 's' : ''}?`}
-        content={Array.from(selectedCollections).join(', ')}
+        content={
+          <ul style={{ margin: 0, paddingLeft: 20 }}>
+            {Array.from(selectedCollections).map((col) => (
+              <li key={col}>{col}</li>
+            ))}
+          </ul>
+        }
         warning={
           'Deleting collections cannot be undone. ' +
           'Make sure you have backed up all important data before proceeding.'

--- a/src/pages/Collections.jsx
+++ b/src/pages/Collections.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useClient } from '../context/client-context';
 import SearchBar from '../components/Collections/SearchBar';
-import { Typography, Grid, Pagination, Box, Skeleton, IconButton, Tooltip } from '@mui/material';
+import { Typography, Grid, Pagination, Box, Skeleton, IconButton, Tooltip, Button } from '@mui/material';
 import { keyframes } from '@mui/material/styles';
 import { RefreshCw } from 'lucide-react';
 import ErrorNotifier from '../components/ToastNotifications/ErrorNotifier';
@@ -12,6 +12,7 @@ import CollectionsList from '../components/Collections/CollectionsList';
 import { debounce } from 'lodash';
 import { useMaxCollections } from '../context/telemetry-context';
 import CreateCollectionButton from '../components/Collections/CreateCollection/CreateCollectionButton';
+import ConfirmationDialog from '../components/Common/ConfirmationDialog';
 
 const spin = keyframes`
   from { transform: rotate(0deg); }
@@ -28,6 +29,9 @@ function Collections() {
   const { client: qdrantClient } = useClient();
   const [currentPage, setCurrentPage] = useState(1);
   const PAGE_SIZE = 5;
+  const [selectedCollections, setSelectedCollections] = useState(new Set());
+  const [openBulkDeleteDialog, setOpenBulkDeleteDialog] = useState(false);
+  const [bulkDeleteError, setBulkDeleteError] = useState(null);
 
   const { maxCollections } = useMaxCollections();
 
@@ -106,6 +110,7 @@ function Collections() {
   }, [currentPage, getCollectionsCall]);
 
   useEffect(() => {
+    setSelectedCollections(new Set());
     if (!searchQuery) {
       getCollectionsCall(currentPage);
     } else {
@@ -143,7 +148,45 @@ function Collections() {
 
   const handlePageChange = (event, value) => {
     setCurrentPage(value);
+    setSelectedCollections(new Set());
   };
+
+  const handleToggleSelect = useCallback((name) => {
+    setSelectedCollections((prev) => {
+      const next = new Set(prev);
+      next.has(name) ? next.delete(name) : next.add(name);
+      return next;
+    });
+  }, []);
+
+  const handleSelectAll = useCallback(
+    (pageCollections) => {
+      const allSelected = pageCollections.every((c) => selectedCollections.has(c.name));
+      if (allSelected) {
+        setSelectedCollections(new Set());
+      } else {
+        setSelectedCollections(new Set(pageCollections.map((c) => c.name)));
+      }
+    },
+    [selectedCollections]
+  );
+
+  const handleBulkDelete = useCallback(async () => {
+    const names = Array.from(selectedCollections);
+    const errors = [];
+    for (const name of names) {
+      try {
+        await qdrantClient.deleteCollection(name);
+      } catch (error) {
+        errors.push(`${name}: ${error.message}`);
+      }
+    }
+    setSelectedCollections(new Set());
+    await getCollectionsCall(currentPage);
+    if (errors.length > 0) {
+      setBulkDeleteError(`Failed to delete: ${errors.join('; ')}`);
+    }
+  }, [selectedCollections, qdrantClient, getCollectionsCall, currentPage]);
 
   const displayCollections = searchQuery ? filteredCollections : collections;
 
@@ -193,6 +236,16 @@ function Collections() {
               md: 7,
             }}
           >
+            {selectedCollections.size > 0 && (
+              <Button
+                variant="contained"
+                color="error"
+                onClick={() => setOpenBulkDeleteDialog(true)}
+                aria-label={`Delete ${selectedCollections.size} selected collection(s)`}
+              >
+                Delete ({selectedCollections.size})
+              </Button>
+            )}
             <CreateCollectionButton onComplete={() => getCollectionsCall(currentPage)} />
             <SnapshotsUpload onComplete={() => getCollectionsCall(currentPage)} key={'snapshots'} />
           </Grid>
@@ -225,6 +278,9 @@ function Collections() {
                 getCollectionsCall={() => getCollectionsCall(currentPage)}
                 refreshCollection={refreshCollection}
                 isRefreshing={isRefreshing}
+                selectedCollections={selectedCollections}
+                handleToggleSelect={handleToggleSelect}
+                handleSelectAll={handleSelectAll}
               />
               {displayCollections && displayCollections.length > PAGE_SIZE && (
                 <Box justifyContent="center" display="flex" mt={3}>
@@ -242,6 +298,19 @@ function Collections() {
           )}
         </Grid>
       </CenteredFrame>
+      {bulkDeleteError && <ErrorNotifier message={bulkDeleteError} />}
+      <ConfirmationDialog
+        open={openBulkDeleteDialog}
+        onClose={() => setOpenBulkDeleteDialog(false)}
+        title={`Delete ${selectedCollections.size} collection${selectedCollections.size !== 1 ? 's' : ''}?`}
+        content={Array.from(selectedCollections).join(', ')}
+        warning={
+          'Deleting collections cannot be undone. ' +
+          'Make sure you have backed up all important data before proceeding.'
+        }
+        actionName={'Delete'}
+        actionHandler={handleBulkDelete}
+      />
     </>
   );
 }

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -138,6 +138,10 @@ const themeOptions = {
           fontWeight: 500,
           lineHeight: '1.4',
           textTransform: 'capitalize',
+          boxShadow: 'none',
+          '&:hover': {
+            boxShadow: 'none',
+          },
         },
         outlinedInherit: ({ theme }) => ({
           border: `1px solid ${theme.palette.divider}`,
@@ -150,10 +154,8 @@ const themeOptions = {
         containedPrimary: ({ theme }) => ({
           background: theme.palette.primary.main,
           color: theme.palette.primary.contrastText,
-          boxShadow: 'none',
           '&:hover': {
             background: theme.palette.primary.dark,
-            boxShadow: 'none',
           },
         }),
       },


### PR DESCRIPTION
## Add Multi-Select Bulk Delete for Collections

### Summary
- Adds a checkbox to each collection row and a "select all" checkbox in the table header, enabling selection of one or more collections at once
- A **Delete (N)** button appears in the top-right header whenever at least one collection is selected
- Clicking Delete opens a confirmation dialog listing the selected collection names before proceeding
- Bulk deletion calls `qdrantClient.deleteCollection()` sequentially for each selected collection, continues on partial failure, and shows an error toast for any that fail
- Selection is automatically cleared on page change or search query change to prevent stale state
- The existing per-row ellipsis → Delete flow is unchanged

### Test plan
- [ ] Checkboxes appear as the first column in each row and in the table header
- [ ] Selecting one checkbox shows the **Delete (N)** button in the header
- [ ] Select-all checkbox selects all rows on the current page; clicking again deselects all (indeterminate state when partially selected)
- [ ] Confirmation dialog lists all selected collection names with a warning before proceeding
- [ ] Confirming deletes all selected collections and refreshes the list
- [ ] Cancelling the dialog leaves all collections intact
- [ ] Selecting rows, then changing page or search query clears the selection
- [ ] Existing single-row ellipsis → Delete still works independently
- [ ] All 127 unit tests pass (`npm test -- --run`)