### PR TITLE
Render collection list even when some collection info requests fail

### DIFF
--- a/src/components/Collections/CollectionsList.jsx
+++ b/src/components/Collections/CollectionsList.jsx
@@ -28,6 +28,50 @@ const CollectionTableRow = ({
   const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
   const theme = useTheme();
 
+  if (collection.error) {
+    return (
+      <StyledTableRow selected={isSelected}>
+        <TableCell padding="checkbox">
+          <Checkbox
+            checked={isSelected}
+            onChange={() => onToggleSelect(collection.name)}
+            inputProps={{ 'aria-label': `Select collection ${collection.name}` }}
+            size="small"
+          />
+        </TableCell>
+        <TableCell>
+          <Typography component={StyledLink} to={`/collections/${encodeURIComponent(collection.name)}`}>
+            {collection.name}
+          </Typography>
+          <Typography component={'p'} variant="caption" color="text.secondary">
+            {collection.aliases && collection.aliases.length > 0 && `Aliases: ${collection.aliases.join(', ')}`}
+          </Typography>
+        </TableCell>
+        <TableCell colSpan={5}>
+          <Typography variant="body2" color="error.main">
+            ⚠ Error: {collection.error}
+          </Typography>
+        </TableCell>
+        <TableCell align="right">
+          <ActionsMenu>
+            <MenuItem onClick={() => refreshCollection(collection.name)} disabled={isRefreshing}>
+              Refresh
+            </MenuItem>
+            <MenuItem onClick={() => setOpenDeleteDialog(true)} sx={{ color: theme.palette.error.main }}>
+              Delete
+            </MenuItem>
+          </ActionsMenu>
+          <DeleteDialog
+            open={openDeleteDialog}
+            setOpen={setOpenDeleteDialog}
+            collectionName={collection.name}
+            getCollectionsCall={getCollectionsCall}
+          />
+        </TableCell>
+      </StyledTableRow>
+    );
+  }
+
   return (
     <StyledTableRow selected={isSelected}>
       <TableCell padding="checkbox">

--- a/src/components/Collections/collectionList.test.jsx
+++ b/src/components/Collections/collectionList.test.jsx
@@ -137,6 +137,35 @@ describe('CollectionsList', () => {
     expect(mockRefresh).toHaveBeenCalledWith(COLLECTIONS[0].name);
   });
 
+  it('should render an error row while keeping name and Delete available for unreadable collections', () => {
+    const COLLECTIONS_WITH_ERROR = [
+      COLLECTIONS[0],
+      {
+        name: 'Broken Collection',
+        error: 'Service internal error: something went wrong',
+        aliases: [],
+      },
+    ];
+    render(
+      <MemoryRouter>
+        <CollectionsList
+          collections={COLLECTIONS_WITH_ERROR}
+          getCollectionsCall={() => {}}
+          refreshCollection={vi.fn()}
+          isRefreshing={false}
+          {...DEFAULT_SELECTION_PROPS}
+        />
+      </MemoryRouter>
+    );
+    // Healthy collections still render alongside the broken one
+    expect(screen.getByText('Collection 1')).toBeInTheDocument();
+    // Broken collection keeps its name visible and surfaces the error
+    expect(screen.getByText('Broken Collection')).toBeInTheDocument();
+    expect(screen.getByText(/Service internal error: something went wrong/)).toBeInTheDocument();
+    // Delete action remains available for the broken collection
+    expect(screen.getAllByText('Delete')).toHaveLength(COLLECTIONS_WITH_ERROR.length);
+  });
+
   it('should disable Refresh menu item when isRefreshing is true', () => {
     render(
       <MemoryRouter>

--- a/src/pages/Collections.jsx
+++ b/src/pages/Collections.jsx
@@ -55,15 +55,23 @@ function Collections() {
 
         const nextRawCollections = await Promise.all(
           nextPageCollections.map(async (collection) => {
-            const collectionData = await qdrantClient.getCollection(collection.name);
             const collectionAliases = aliases.aliases
               .filter((alias) => alias.collection_name === collection.name)
               .map((alias) => alias.alias_name);
-            return {
-              name: collection.name,
-              ...collectionData,
-              aliases: [...collectionAliases],
-            };
+            try {
+              const collectionData = await qdrantClient.getCollection(collection.name);
+              return {
+                name: collection.name,
+                ...collectionData,
+                aliases: [...collectionAliases],
+              };
+            } catch (error) {
+              return {
+                name: collection.name,
+                error: getErrorMessageWithApiKey(error) || 'Failed to load collection info',
+                aliases: [...collectionAliases],
+              };
+            }
           })
         );
 
@@ -86,11 +94,18 @@ function Collections() {
         setFilteredCollections(filtered);
         const nextRawCollections = await Promise.all(
           filtered.map(async (collection) => {
-            const collectionData = await qdrantClient.getCollection(collection.name);
-            return {
-              name: collection.name,
-              ...collectionData,
-            };
+            try {
+              const collectionData = await qdrantClient.getCollection(collection.name);
+              return {
+                name: collection.name,
+                ...collectionData,
+              };
+            } catch (error) {
+              return {
+                name: collection.name,
+                error: getErrorMessageWithApiKey(error) || 'Failed to load collection info',
+              };
+            }
           })
         );
 
@@ -134,11 +149,13 @@ function Collections() {
       setIsRefreshing(true);
       try {
         const collectionData = await qdrantClient.getCollection(collectionName);
-        setRawCollections((prev) => prev.map((c) => (c.name === collectionName ? { ...c, ...collectionData } : c)));
+        setRawCollections((prev) =>
+          prev.map((c) => (c.name === collectionName ? { ...c, ...collectionData, error: null } : c))
+        );
         setErrorMessage(null);
       } catch (error) {
-        const message = getErrorMessageWithApiKey(error);
-        message && setErrorMessage(message);
+        const message = getErrorMessageWithApiKey(error) || 'Failed to load collection info';
+        setRawCollections((prev) => prev.map((c) => (c.name === collectionName ? { ...c, error: message } : c)));
       } finally {
         setIsRefreshing(false);
       }


### PR DESCRIPTION
## Problem

When rendering the collections list, per-collection info was fetched with `Promise.all(...getCollection(name))`. `Promise.all` rejects as soon as any single request fails, which sent control to the `catch` block, cleared `rawCollections`, and displayed only a global error.

The result: **one collection whose info couldn't be read hid the entire list**, leaving users unable to detect or fix the problematic collection on their own.

## Fix

- `src/pages/Collections.jsx` — `getCollectionsCall` and `getFilteredCollectionsCall`: each per-collection `getCollection` call now has its own `try/catch`. On failure it returns `{ name, error, aliases }` instead of throwing, so `Promise.all` no longer rejects. The outer `catch` (global error) is now reserved for genuine whole-list failures (`getCollections` / `getAliases`).
- `refreshCollection`: a successful refresh clears a prior row error; a failed refresh marks that specific row instead of only showing a global toast.
- `src/components/Collections/CollectionsList.jsx` — `CollectionTableRow` renders a dedicated error row when `collection.error` is set. It keeps the **collection name** (as a link) and the **Delete** action (plus Refresh) available, and shows `⚠ Error: <message>` inline across the data columns.

## Result

The list renders fully, with only the unreadable collections flagged. Their name stays visible and they can still be deleted.

## Tests

Added a test asserting healthy collections still render alongside a broken one, the broken collection keeps its name and surfaces its error, and Delete remains available. All 6 tests in `collectionList.test.jsx` pass; ESLint is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)