### PR TITLE
Visualization: WebGL2 scatter renderer (Scale Viz M3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@mui/x-data-grid": "^7.29.1",
         "@qdrant/graph-layout-wasm": "github:qdrant/graph-layout-wasm#master",
         "@qdrant/js-client-rest": "^1.15.1",
-        "@saehrimnir/druidjs": "^0.6.3",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -1806,8 +1805,8 @@
       }
     },
     "node_modules/@qdrant/graph-layout-wasm": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/qdrant/graph-layout-wasm.git#e70ea04a8e6d04f1a17c9fd3b18bdc3f43958c4d",
+      "version": "0.2.0",
+      "resolved": "git+ssh://git@github.com/qdrant/graph-layout-wasm.git#25ac7c69e1549c0dd2ff9b9b3b1c2d285a34df0f",
       "license": "Apache-2.0"
     },
     "node_modules/@qdrant/js-client-rest": {
@@ -2195,13 +2194,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@saehrimnir/druidjs": {
-      "version": "0.6.3",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/@sevinf/maybe": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@mui/x-data-grid": "^7.29.1",
     "@qdrant/graph-layout-wasm": "github:qdrant/graph-layout-wasm#master",
     "@qdrant/js-client-rest": "^1.15.1",
-    "@saehrimnir/druidjs": "^0.6.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/components/VisualizeChart/ScatterGL.js
+++ b/src/components/VisualizeChart/ScatterGL.js
@@ -1,0 +1,466 @@
+import chroma from 'chroma-js';
+
+// Minimal WebGL2 scatter plot renderer.
+//
+// Renders points as instanced circular sprites from a single Float32Array of
+// positions, so updating an animation frame is one buffer upload. Scales to
+// hundreds of thousands of points, which Chart.js (2D canvas) cannot.
+//
+// Interactions: wheel zoom (cursor-centered), drag pan, exact hover/click
+// hit-testing via an offscreen picking framebuffer with color-encoded ids.
+
+const POINT_VERTEX_SHADER = `#version 300 es
+precision highp float;
+in vec2 a_position;
+in vec4 a_color;
+in float a_visible;
+uniform vec2 u_scale;
+uniform vec2 u_offset;
+uniform float u_pointSize;
+out vec4 v_color;
+void main() {
+  if (a_visible < 0.5) {
+    // Clip hidden points away
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    gl_PointSize = 0.0;
+    v_color = vec4(0.0);
+    return;
+  }
+  vec2 p = a_position * u_scale + u_offset;
+  gl_Position = vec4(p, 0.0, 1.0);
+  gl_PointSize = u_pointSize;
+  v_color = a_color;
+}`;
+
+const POINT_FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+in vec4 v_color;
+out vec4 outColor;
+void main() {
+  vec2 c = gl_PointCoord - vec2(0.5);
+  float dist = length(c);
+  if (dist > 0.5) discard;
+  // Soft edge
+  float alpha = v_color.a * smoothstep(0.5, 0.42, dist);
+  outColor = vec4(v_color.rgb * alpha, alpha);
+}`;
+
+const PICKING_FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+in vec4 v_color;
+out vec4 outColor;
+void main() {
+  vec2 c = gl_PointCoord - vec2(0.5);
+  if (length(c) > 0.5) discard;
+  outColor = v_color;
+}`;
+
+const CLICK_TOLERANCE_PX = 4;
+
+function compileProgram(gl, vertexSource, fragmentSource) {
+  const compile = (type, source) => {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+      throw new Error('Shader compile error: ' + gl.getShaderInfoLog(shader));
+    }
+    return shader;
+  };
+  const program = gl.createProgram();
+  gl.attachShader(program, compile(gl.VERTEX_SHADER, vertexSource));
+  gl.attachShader(program, compile(gl.FRAGMENT_SHADER, fragmentSource));
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    throw new Error('Program link error: ' + gl.getProgramInfoLog(program));
+  }
+  return program;
+}
+
+export default class ScatterGL {
+  constructor(canvas, { onHover = null, onClick = null, pointSize = 7 } = {}) {
+    this.canvas = canvas;
+    this.onHover = onHover;
+    this.onClick = onClick;
+    this.basePointSize = pointSize;
+
+    const gl = canvas.getContext('webgl2', { antialias: true, alpha: true });
+    if (!gl) {
+      throw new Error('WebGL2 is not supported by this browser');
+    }
+    this.gl = gl;
+
+    this.program = compileProgram(gl, POINT_VERTEX_SHADER, POINT_FRAGMENT_SHADER);
+    this.pickingProgram = compileProgram(gl, POINT_VERTEX_SHADER, PICKING_FRAGMENT_SHADER);
+
+    this.n = 0;
+    this.positions = null;
+    this.positionBuffer = gl.createBuffer();
+    this.colorBuffer = gl.createBuffer();
+    this.pickingColorBuffer = gl.createBuffer();
+    this.visibilityBuffer = gl.createBuffer();
+
+    // View transform: world -> clip. Updated by fit / pan / zoom.
+    this.viewScale = [1, 1];
+    this.viewOffset = [0, 0];
+    this.userAdjustedView = false;
+
+    this.hoveredIndex = null;
+    this.highlightIndex = null;
+    this.renderScheduled = false;
+    this.pickingDirty = true;
+    this.destroyed = false;
+
+    this.pickingFramebuffer = gl.createFramebuffer();
+    this.pickingTexture = gl.createTexture();
+    this.pickingDepth = null;
+
+    this.setupVertexArrays();
+    this.attachEvents();
+    this.resize();
+
+    this.resizeObserver = new ResizeObserver(() => {
+      this.resize();
+      this.requestRender();
+    });
+    this.resizeObserver.observe(canvas.parentElement ?? canvas);
+  }
+
+  setupVertexArrays() {
+    const gl = this.gl;
+    const configure = (program, colorBuffer) => {
+      const vao = gl.createVertexArray();
+      gl.bindVertexArray(vao);
+
+      const positionLoc = gl.getAttribLocation(program, 'a_position');
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
+      gl.enableVertexAttribArray(positionLoc);
+      gl.vertexAttribPointer(positionLoc, 2, gl.FLOAT, false, 0, 0);
+
+      const colorLoc = gl.getAttribLocation(program, 'a_color');
+      gl.bindBuffer(gl.ARRAY_BUFFER, colorBuffer);
+      gl.enableVertexAttribArray(colorLoc);
+      gl.vertexAttribPointer(colorLoc, 4, gl.UNSIGNED_BYTE, true, 0, 0);
+
+      const visibleLoc = gl.getAttribLocation(program, 'a_visible');
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.visibilityBuffer);
+      gl.enableVertexAttribArray(visibleLoc);
+      gl.vertexAttribPointer(visibleLoc, 1, gl.UNSIGNED_BYTE, true, 0, 0);
+
+      gl.bindVertexArray(null);
+      return vao;
+    };
+    this.vao = configure(this.program, this.colorBuffer);
+    this.pickingVao = configure(this.pickingProgram, this.pickingColorBuffer);
+  }
+
+  // ---- data ----
+
+  setData(n) {
+    const gl = this.gl;
+    this.n = n;
+    this.positions = null;
+    this.hoveredIndex = null;
+    this.highlightIndex = null;
+    this.userAdjustedView = false;
+
+    // Picking colors encode index + 1 as RGB (0 = background)
+    const pickingColors = new Uint8Array(n * 4);
+    for (let i = 0; i < n; i++) {
+      const id = i + 1;
+      pickingColors[i * 4] = id & 0xff;
+      pickingColors[i * 4 + 1] = (id >> 8) & 0xff;
+      pickingColors[i * 4 + 2] = (id >> 16) & 0xff;
+      pickingColors[i * 4 + 3] = 255;
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.pickingColorBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, pickingColors, gl.STATIC_DRAW);
+
+    this.setVisibility(null);
+  }
+
+  // `colors` is an array of CSS color strings, one per point
+  setColors(colors) {
+    const gl = this.gl;
+    const rgba = new Uint8Array(colors.length * 4);
+    const cache = {};
+    for (let i = 0; i < colors.length; i++) {
+      let parsed = cache[colors[i]];
+      if (!parsed) {
+        parsed = chroma(colors[i]).rgba();
+        parsed[3] = Math.round(parsed[3] * 255);
+        cache[colors[i]] = parsed;
+      }
+      rgba.set(parsed, i * 4);
+    }
+    this.pointColors = rgba;
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.colorBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, rgba, gl.DYNAMIC_DRAW);
+    this.requestRender();
+  }
+
+  // `visible` is a Uint8Array of 0/1 per point, or null for all-visible
+  setVisibility(visible) {
+    const gl = this.gl;
+    const data = visible ?? new Uint8Array(this.n).fill(255);
+    if (visible) {
+      for (let i = 0; i < data.length; i++) {
+        data[i] = data[i] ? 255 : 0;
+      }
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.visibilityBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, data, gl.DYNAMIC_DRAW);
+    this.pickingDirty = true;
+    this.requestRender();
+  }
+
+  // `positions` is a Float32Array [x0, y0, x1, y1, ...]
+  updatePositions(positions) {
+    const gl = this.gl;
+    this.positions = positions;
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.DYNAMIC_DRAW);
+    if (!this.userAdjustedView) {
+      this.fitView();
+    }
+    this.pickingDirty = true;
+    this.requestRender();
+  }
+
+  fitView() {
+    if (!this.positions || this.n === 0) return;
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    for (let i = 0; i < this.n; i++) {
+      const x = this.positions[i * 2];
+      const y = this.positions[i * 2 + 1];
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+    const spanX = maxX - minX || 1;
+    const spanY = maxY - minY || 1;
+    const padding = 1.1;
+    this.viewScale = [2 / (spanX * padding), 2 / (spanY * padding)];
+    this.viewOffset = [(-(minX + maxX) / 2 / (spanX * padding)) * 2, (-(minY + maxY) / 2 / (spanY * padding)) * 2];
+  }
+
+  // ---- rendering ----
+
+  resize() {
+    const canvas = this.canvas;
+    const dpr = window.devicePixelRatio || 1;
+    const width = Math.max(1, Math.floor(canvas.clientWidth * dpr));
+    const height = Math.max(1, Math.floor(canvas.clientHeight * dpr));
+    if (canvas.width !== width || canvas.height !== height) {
+      canvas.width = width;
+      canvas.height = height;
+      this.resizePickingTarget(width, height);
+      this.pickingDirty = true;
+    }
+  }
+
+  resizePickingTarget(width, height) {
+    const gl = this.gl;
+    gl.bindTexture(gl.TEXTURE_2D, this.pickingTexture);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.pickingFramebuffer);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this.pickingTexture, 0);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  }
+
+  requestRender() {
+    if (this.renderScheduled || this.destroyed) return;
+    this.renderScheduled = true;
+    requestAnimationFrame(() => {
+      this.renderScheduled = false;
+      if (!this.destroyed) this.render();
+    });
+  }
+
+  pointSizePx() {
+    return this.basePointSize * (window.devicePixelRatio || 1);
+  }
+
+  render() {
+    const gl = this.gl;
+    if (!this.positions || this.n === 0) {
+      gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+      gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+      gl.clearColor(0, 0, 0, 0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      return;
+    }
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.enable(gl.BLEND);
+    // Premultiplied alpha
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+
+    gl.useProgram(this.program);
+    gl.bindVertexArray(this.vao);
+    gl.uniform2fv(gl.getUniformLocation(this.program, 'u_scale'), this.viewScale);
+    gl.uniform2fv(gl.getUniformLocation(this.program, 'u_offset'), this.viewOffset);
+    gl.uniform1f(gl.getUniformLocation(this.program, 'u_pointSize'), this.pointSizePx());
+    gl.drawArrays(gl.POINTS, 0, this.n);
+
+    // Emphasize the hovered point by re-drawing it larger
+    if (this.highlightIndex !== null && this.highlightIndex < this.n) {
+      gl.uniform1f(gl.getUniformLocation(this.program, 'u_pointSize'), this.pointSizePx() * 1.8);
+      gl.drawArrays(gl.POINTS, this.highlightIndex, 1);
+    }
+    gl.bindVertexArray(null);
+  }
+
+  setHighlight(index) {
+    if (index !== this.highlightIndex) {
+      this.highlightIndex = index;
+      this.requestRender();
+    }
+  }
+
+  renderPicking() {
+    const gl = this.gl;
+    if (!this.positions || this.n === 0) return;
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.pickingFramebuffer);
+    gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    gl.disable(gl.BLEND);
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    gl.useProgram(this.pickingProgram);
+    gl.bindVertexArray(this.pickingVao);
+    gl.uniform2fv(gl.getUniformLocation(this.pickingProgram, 'u_scale'), this.viewScale);
+    gl.uniform2fv(gl.getUniformLocation(this.pickingProgram, 'u_offset'), this.viewOffset);
+    // Slightly larger for forgiving hit-testing
+    gl.uniform1f(gl.getUniformLocation(this.pickingProgram, 'u_pointSize'), this.pointSizePx() + 4);
+    gl.drawArrays(gl.POINTS, 0, this.n);
+    gl.bindVertexArray(null);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    this.pickingDirty = false;
+  }
+
+  pick(clientX, clientY) {
+    const gl = this.gl;
+    if (!this.positions || this.n === 0) return null;
+    if (this.pickingDirty) {
+      this.renderPicking();
+    }
+    const rect = this.canvas.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    const x = Math.floor((clientX - rect.left) * dpr);
+    const y = Math.floor((rect.bottom - clientY) * dpr);
+    const pixel = new Uint8Array(4);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.pickingFramebuffer);
+    gl.readPixels(x, y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    const id = pixel[0] | (pixel[1] << 8) | (pixel[2] << 16);
+    return id === 0 ? null : id - 1;
+  }
+
+  // ---- interactions ----
+
+  attachEvents() {
+    const canvas = this.canvas;
+    this.dragState = null;
+
+    this.handlePointerDown = (e) => {
+      this.dragState = { x: e.clientX, y: e.clientY, moved: 0 };
+      canvas.setPointerCapture(e.pointerId);
+    };
+
+    this.handlePointerMove = (e) => {
+      if (this.dragState) {
+        const dx = e.clientX - this.dragState.x;
+        const dy = e.clientY - this.dragState.y;
+        this.dragState.x = e.clientX;
+        this.dragState.y = e.clientY;
+        this.dragState.moved += Math.abs(dx) + Math.abs(dy);
+        if (this.dragState.moved > CLICK_TOLERANCE_PX) {
+          const rect = canvas.getBoundingClientRect();
+          this.viewOffset[0] += (dx / rect.width) * 2;
+          this.viewOffset[1] -= (dy / rect.height) * 2;
+          this.userAdjustedView = true;
+          this.pickingDirty = true;
+          this.requestRender();
+        }
+        return;
+      }
+      const index = this.pick(e.clientX, e.clientY);
+      if (index !== this.hoveredIndex) {
+        this.hoveredIndex = index;
+        if (this.onHover) this.onHover(index, e.clientX, e.clientY);
+      } else if (index !== null && this.onHover) {
+        // Same point, but let the tooltip follow the cursor
+        this.onHover(index, e.clientX, e.clientY);
+      }
+    };
+
+    this.handlePointerUp = (e) => {
+      const wasClick = this.dragState && this.dragState.moved <= CLICK_TOLERANCE_PX;
+      this.dragState = null;
+      if (wasClick && this.onClick) {
+        const index = this.pick(e.clientX, e.clientY);
+        if (index !== null) this.onClick(index);
+      }
+    };
+
+    this.handlePointerLeave = () => {
+      if (this.hoveredIndex !== null) {
+        this.hoveredIndex = null;
+        if (this.onHover) this.onHover(null, 0, 0);
+      }
+    };
+
+    this.handleWheel = (e) => {
+      e.preventDefault();
+      const rect = canvas.getBoundingClientRect();
+      // Cursor position in clip space
+      const cx = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+      const cy = -(((e.clientY - rect.top) / rect.height) * 2 - 1);
+      const factor = Math.exp(-e.deltaY * 0.002);
+      for (const axis of [0, 1]) {
+        const c = axis === 0 ? cx : cy;
+        this.viewScale[axis] *= factor;
+        this.viewOffset[axis] = c - (c - this.viewOffset[axis]) * factor;
+      }
+      this.userAdjustedView = true;
+      this.pickingDirty = true;
+      this.requestRender();
+    };
+
+    canvas.addEventListener('pointerdown', this.handlePointerDown);
+    canvas.addEventListener('pointermove', this.handlePointerMove);
+    canvas.addEventListener('pointerup', this.handlePointerUp);
+    canvas.addEventListener('pointerleave', this.handlePointerLeave);
+    canvas.addEventListener('wheel', this.handleWheel, { passive: false });
+  }
+
+  destroy() {
+    this.destroyed = true;
+    this.resizeObserver.disconnect();
+    const canvas = this.canvas;
+    canvas.removeEventListener('pointerdown', this.handlePointerDown);
+    canvas.removeEventListener('pointermove', this.handlePointerMove);
+    canvas.removeEventListener('pointerup', this.handlePointerUp);
+    canvas.removeEventListener('pointerleave', this.handlePointerLeave);
+    canvas.removeEventListener('wheel', this.handleWheel);
+    const gl = this.gl;
+    gl.deleteBuffer(this.positionBuffer);
+    gl.deleteBuffer(this.colorBuffer);
+    gl.deleteBuffer(this.pickingColorBuffer);
+    gl.deleteBuffer(this.visibilityBuffer);
+    gl.deleteFramebuffer(this.pickingFramebuffer);
+    gl.deleteTexture(this.pickingTexture);
+    gl.deleteProgram(this.program);
+    gl.deleteProgram(this.pickingProgram);
+  }
+}

--- a/src/components/VisualizeChart/ScatterGL.js
+++ b/src/components/VisualizeChart/ScatterGL.js
@@ -35,14 +35,22 @@ void main() {
 const POINT_FRAGMENT_SHADER = `#version 300 es
 precision highp float;
 in vec4 v_color;
+uniform float u_ring;      // 0 = filled disc, 1 = ring outline (selected marker)
+uniform vec4 u_ringColor;  // ring color, used only when u_ring == 1
 out vec4 outColor;
 void main() {
   vec2 c = gl_PointCoord - vec2(0.5);
   float dist = length(c);
   if (dist > 0.5) discard;
-  // Soft edge
-  float alpha = v_color.a * smoothstep(0.5, 0.42, dist);
-  outColor = vec4(v_color.rgb * alpha, alpha);
+  if (u_ring > 0.5) {
+    // Annulus: opaque near the rim, hollow in the middle
+    float a = u_ringColor.a * smoothstep(0.30, 0.40, dist) * smoothstep(0.5, 0.44, dist);
+    outColor = vec4(u_ringColor.rgb * a, a);
+  } else {
+    // Soft edge
+    float alpha = v_color.a * smoothstep(0.5, 0.42, dist);
+    outColor = vec4(v_color.rgb * alpha, alpha);
+  }
 }`;
 
 const PICKING_FRAGMENT_SHADER = `#version 300 es
@@ -56,6 +64,9 @@ void main() {
 }`;
 
 const CLICK_TOLERANCE_PX = 4;
+// Positions arriving from the layout worker are tweened over this duration,
+// so the animation reads as continuous motion instead of discrete jumps
+const POSITION_TWEEN_MS = 260;
 
 function compileProgram(gl, vertexSource, fragmentSource) {
   const compile = (type, source) => {
@@ -78,10 +89,15 @@ function compileProgram(gl, vertexSource, fragmentSource) {
 }
 
 export default class ScatterGL {
-  constructor(canvas, { onHover = null, onClick = null, pointSize = 7 } = {}) {
+  constructor(canvas, { onHover = null, onClick = null, onBoxSelect = null, onBoxRect = null, pointSize = 7 } = {}) {
     this.canvas = canvas;
     this.onHover = onHover;
     this.onClick = onClick;
+    // Called with an array of selected point indices after a shift+drag
+    this.onBoxSelect = onBoxSelect;
+    // Called with a pixel-space rect during a shift+drag (null when done),
+    // so the host can render a selection rectangle overlay
+    this.onBoxRect = onBoxRect;
     this.basePointSize = pointSize;
 
     const gl = canvas.getContext('webgl2', { antialias: true, alpha: true });
@@ -107,6 +123,10 @@ export default class ScatterGL {
 
     this.hoveredIndex = null;
     this.highlightIndex = null;
+    // The clicked point, drawn enlarged with a contrasting ring so it stands
+    // out from its (also emphasized) nearest neighbors
+    this.selectedIndex = null;
+    this.selectedRing = [1, 1, 1, 1];
     this.renderScheduled = false;
     this.pickingDirty = true;
     this.destroyed = false;
@@ -160,8 +180,10 @@ export default class ScatterGL {
     const gl = this.gl;
     this.n = n;
     this.positions = null;
+    this.tween = null;
     this.hoveredIndex = null;
     this.highlightIndex = null;
+    this.selectedIndex = null;
     this.userAdjustedView = false;
 
     // Picking colors encode index + 1 as RGB (0 = background)
@@ -208,18 +230,79 @@ export default class ScatterGL {
         data[i] = data[i] ? 255 : 0;
       }
     }
+    this.visibleMask = visible ? data : null;
     gl.bindBuffer(gl.ARRAY_BUFFER, this.visibilityBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, data, gl.DYNAMIC_DRAW);
     this.pickingDirty = true;
     this.requestRender();
   }
 
-  // `positions` is a Float32Array [x0, y0, x1, y1, ...]
-  updatePositions(positions) {
+  // Dim all points except the given indices; null restores full colors
+  setFocus(indices) {
     const gl = this.gl;
-    this.positions = positions;
+    if (!this.pointColors) return;
+    let data = this.pointColors;
+    if (indices !== null) {
+      data = new Uint8Array(this.pointColors);
+      for (let i = 0; i < this.n; i++) {
+        data[i * 4 + 3] = Math.round(data[i * 4 + 3] * 0.15);
+      }
+      for (const index of indices) {
+        data[index * 4 + 3] = this.pointColors[index * 4 + 3];
+      }
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.colorBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, data, gl.DYNAMIC_DRAW);
+    this.requestRender();
+  }
+
+  // `positions` is a Float32Array [x0, y0, x1, y1, ...].
+  // The first update is applied directly, subsequent ones are tweened.
+  updatePositions(positions) {
+    if (!this.positions || this.positions.length !== positions.length) {
+      this.positions = positions;
+      this.tween = null;
+      this.uploadPositions();
+      return;
+    }
+    this.tween = {
+      from: this.positions.slice(),
+      to: positions,
+      start: performance.now(),
+    };
+    this.runTween();
+  }
+
+  runTween() {
+    if (this.tweenRunning) return;
+    this.tweenRunning = true;
+    const frame = () => {
+      if (this.destroyed || !this.tween) {
+        this.tweenRunning = false;
+        return;
+      }
+      const { from, to, start } = this.tween;
+      const t = Math.min(1, (performance.now() - start) / POSITION_TWEEN_MS);
+      const eased = t * (2 - t); // ease-out
+      const positions = this.positions;
+      for (let i = 0; i < positions.length; i++) {
+        positions[i] = from[i] + (to[i] - from[i]) * eased;
+      }
+      this.uploadPositions();
+      if (t >= 1) {
+        this.tween = null;
+        this.tweenRunning = false;
+        return;
+      }
+      requestAnimationFrame(frame);
+    };
+    requestAnimationFrame(frame);
+  }
+
+  uploadPositions() {
+    const gl = this.gl;
     gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.DYNAMIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, this.positions, gl.DYNAMIC_DRAW);
     if (!this.userAdjustedView) {
       this.fitView();
     }
@@ -309,13 +392,28 @@ export default class ScatterGL {
     gl.bindVertexArray(this.vao);
     gl.uniform2fv(gl.getUniformLocation(this.program, 'u_scale'), this.viewScale);
     gl.uniform2fv(gl.getUniformLocation(this.program, 'u_offset'), this.viewOffset);
-    gl.uniform1f(gl.getUniformLocation(this.program, 'u_pointSize'), this.pointSizePx());
+    const uPointSize = gl.getUniformLocation(this.program, 'u_pointSize');
+    const uRing = gl.getUniformLocation(this.program, 'u_ring');
+    gl.uniform1f(uRing, 0);
+    gl.uniform1f(uPointSize, this.pointSizePx());
     gl.drawArrays(gl.POINTS, 0, this.n);
 
     // Emphasize the hovered point by re-drawing it larger
     if (this.highlightIndex !== null && this.highlightIndex < this.n) {
-      gl.uniform1f(gl.getUniformLocation(this.program, 'u_pointSize'), this.pointSizePx() * 1.8);
+      gl.uniform1f(uPointSize, this.pointSizePx() * 1.8);
       gl.drawArrays(gl.POINTS, this.highlightIndex, 1);
+    }
+
+    // Mark the selected point: redraw it larger in its own color, then wrap it
+    // in a contrasting ring so it is distinct from the emphasized neighbors
+    if (this.selectedIndex !== null && this.selectedIndex < this.n) {
+      gl.uniform1f(uPointSize, this.pointSizePx() * 1.5);
+      gl.drawArrays(gl.POINTS, this.selectedIndex, 1);
+      gl.uniform1f(uRing, 1);
+      gl.uniform4fv(gl.getUniformLocation(this.program, 'u_ringColor'), this.selectedRing);
+      gl.uniform1f(uPointSize, this.pointSizePx() * 2.6);
+      gl.drawArrays(gl.POINTS, this.selectedIndex, 1);
+      gl.uniform1f(uRing, 0);
     }
     gl.bindVertexArray(null);
   }
@@ -323,6 +421,19 @@ export default class ScatterGL {
   setHighlight(index) {
     if (index !== this.highlightIndex) {
       this.highlightIndex = index;
+      this.requestRender();
+    }
+  }
+
+  // Mark a single point as selected (the clicked one). `color` is a CSS color
+  // string for the ring; pass null as index to clear the marker.
+  setSelected(index, color) {
+    if (color) {
+      const c = chroma(color).rgba();
+      this.selectedRing = [c[0] / 255, c[1] / 255, c[2] / 255, c[3]];
+    }
+    if (index !== this.selectedIndex || color) {
+      this.selectedIndex = index;
       this.requestRender();
     }
   }
@@ -368,16 +479,65 @@ export default class ScatterGL {
 
   // ---- interactions ----
 
+  clientToWorld(clientX, clientY) {
+    const rect = this.canvas.getBoundingClientRect();
+    const clipX = ((clientX - rect.left) / rect.width) * 2 - 1;
+    const clipY = -(((clientY - rect.top) / rect.height) * 2 - 1);
+    return [(clipX - this.viewOffset[0]) / this.viewScale[0], (clipY - this.viewOffset[1]) / this.viewScale[1]];
+  }
+
+  // Indices of visible points inside a client-space rectangle
+  selectInBox({ x0, y0, x1, y1 }) {
+    if (!this.positions) return [];
+    const [wx0, wy0] = this.clientToWorld(x0, y0);
+    const [wx1, wy1] = this.clientToWorld(x1, y1);
+    const minX = Math.min(wx0, wx1);
+    const maxX = Math.max(wx0, wx1);
+    const minY = Math.min(wy0, wy1);
+    const maxY = Math.max(wy0, wy1);
+    const selected = [];
+    for (let i = 0; i < this.n; i++) {
+      if (this.visibleMask && !this.visibleMask[i]) continue;
+      const x = this.positions[i * 2];
+      const y = this.positions[i * 2 + 1];
+      if (x >= minX && x <= maxX && y >= minY && y <= maxY) {
+        selected.push(i);
+      }
+    }
+    return selected;
+  }
+
   attachEvents() {
     const canvas = this.canvas;
     this.dragState = null;
+    this.boxState = null;
 
     this.handlePointerDown = (e) => {
+      if (e.shiftKey && this.onBoxSelect) {
+        this.boxState = { x0: e.clientX, y0: e.clientY, x1: e.clientX, y1: e.clientY };
+        canvas.setPointerCapture(e.pointerId);
+        return;
+      }
       this.dragState = { x: e.clientX, y: e.clientY, moved: 0 };
       canvas.setPointerCapture(e.pointerId);
     };
 
     this.handlePointerMove = (e) => {
+      if (this.boxState) {
+        this.boxState.x1 = e.clientX;
+        this.boxState.y1 = e.clientY;
+        if (this.onBoxRect) {
+          const rect = canvas.getBoundingClientRect();
+          const { x0, y0, x1, y1 } = this.boxState;
+          this.onBoxRect({
+            left: Math.min(x0, x1) - rect.left,
+            top: Math.min(y0, y1) - rect.top,
+            width: Math.abs(x1 - x0),
+            height: Math.abs(y1 - y0),
+          });
+        }
+        return;
+      }
       if (this.dragState) {
         const dx = e.clientX - this.dragState.x;
         const dy = e.clientY - this.dragState.y;
@@ -405,11 +565,18 @@ export default class ScatterGL {
     };
 
     this.handlePointerUp = (e) => {
+      if (this.boxState) {
+        const selected = this.selectInBox(this.boxState);
+        this.boxState = null;
+        if (this.onBoxRect) this.onBoxRect(null);
+        if (this.onBoxSelect) this.onBoxSelect(selected);
+        return;
+      }
       const wasClick = this.dragState && this.dragState.moved <= CLICK_TOLERANCE_PX;
       this.dragState = null;
       if (wasClick && this.onClick) {
-        const index = this.pick(e.clientX, e.clientY);
-        if (index !== null) this.onClick(index);
+        // null = click on empty space (used to clear selection)
+        this.onClick(this.pick(e.clientX, e.clientY));
       }
     };
 

--- a/src/components/VisualizeChart/SelectionPanel.jsx
+++ b/src/components/VisualizeChart/SelectionPanel.jsx
@@ -1,0 +1,127 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { Box, Button, Stack, Typography } from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import FilterAltIcon from '@mui/icons-material/FilterAlt';
+import DataObjectIcon from '@mui/icons-material/DataObject';
+import { DataGrid } from '@mui/x-data-grid';
+import { useSnackbar } from 'notistack';
+import { bigIntJSON } from '../../common/bigIntJSON';
+
+// How many payload fields get their own table column
+const MAX_PAYLOAD_COLUMNS = 8;
+
+function formatCell(value) {
+  if (value === undefined) {
+    return '';
+  }
+  if (value !== null && typeof value === 'object') {
+    return bigIntJSON.stringify(value);
+  }
+  return String(value);
+}
+
+// Table view of the points selected in the chart, with copy actions
+// for external analysis
+const SelectionPanel = ({ points, onPointClick }) => {
+  const { enqueueSnackbar } = useSnackbar();
+
+  const payloadKeys = useMemo(() => {
+    const keys = [];
+    for (const point of points.slice(0, 100)) {
+      for (const key of Object.keys(point.payload ?? {})) {
+        if (!keys.includes(key)) {
+          keys.push(key);
+        }
+      }
+      if (keys.length >= MAX_PAYLOAD_COLUMNS) {
+        break;
+      }
+    }
+    return keys.slice(0, MAX_PAYLOAD_COLUMNS);
+  }, [points]);
+
+  const columns = useMemo(
+    () => [
+      { field: 'id', headerName: 'id', width: 110 },
+      ...payloadKeys.map((key) => ({
+        field: `payload.${key}`,
+        headerName: key,
+        flex: 1,
+        minWidth: 130,
+        sortable: false,
+        renderCell: (params) => formatCell(params.row.point.payload?.[key]),
+      })),
+    ],
+    [payloadKeys]
+  );
+
+  const rows = useMemo(() => points.map((point) => ({ id: String(point.id), point })), [points]);
+
+  const copyToClipboard = async (label, text) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      enqueueSnackbar(`${label} copied to clipboard`, { variant: 'success' });
+    } catch (e) {
+      enqueueSnackbar(`Copy failed: ${e.message}`, { variant: 'error' });
+    }
+  };
+
+  const copyIds = () => copyToClipboard('Point ids', bigIntJSON.stringify(points.map((point) => point.id)));
+
+  const copyJson = () =>
+    copyToClipboard(
+      'Points',
+      bigIntJSON.stringify(
+        points.map(({ id, payload, score }) => ({ id, payload, ...(score !== undefined && { score }) })),
+        null,
+        2
+      )
+    );
+
+  const copyFilter = () =>
+    copyToClipboard('Filter', bigIntJSON.stringify({ must: [{ has_id: points.map((point) => point.id) }] }, null, 2));
+
+  return (
+    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap sx={{ p: 1 }}>
+        <Typography variant="subtitle2" sx={{ flexGrow: 1 }}>
+          {points.length} selected points
+        </Typography>
+        <Button size="small" startIcon={<ContentCopyIcon />} onClick={copyIds}>
+          Copy ids
+        </Button>
+        <Button size="small" startIcon={<DataObjectIcon />} onClick={copyJson}>
+          Copy JSON
+        </Button>
+        <Button
+          size="small"
+          startIcon={<FilterAltIcon />}
+          onClick={copyFilter}
+          title="Qdrant filter matching the selection"
+        >
+          Copy filter
+        </Button>
+      </Stack>
+      <Box sx={{ flex: 1, minHeight: 0 }}>
+        <DataGrid
+          rows={rows}
+          columns={columns}
+          density="compact"
+          disableRowSelectionOnClick
+          onRowClick={(params) => onPointClick?.(params.row.point)}
+          initialState={{ pagination: { paginationModel: { pageSize: 100 } } }}
+          pageSizeOptions={[100]}
+          sx={{ border: 0, '& .MuiDataGrid-row': { cursor: 'pointer' } }}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+SelectionPanel.propTypes = {
+  points: PropTypes.array.isRequired,
+  onPointClick: PropTypes.func,
+};
+
+export default SelectionPanel;

--- a/src/components/VisualizeChart/index.jsx
+++ b/src/components/VisualizeChart/index.jsx
@@ -1,223 +1,111 @@
-import Chart from 'chart.js/auto';
-import get from 'lodash/get';
 import { useSnackbar } from 'notistack';
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
-import { generateColorBy, generateSizeBy } from './renderBy';
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
+import get from 'lodash/get';
+import ScatterGL from './ScatterGL';
+import { generateColorBy } from './renderBy';
 
-// Dark red
-const LIGHT_SELECTOR_COLOR = 'rgba(255, 0, 0, 0.5)';
-// White
-const DARK_SELECTOR_COLOR = 'rgba(245, 245, 245, 0.8)';
-
-// Transparent color for points
-const DEFAULT_BORDER_COLOR = 'rgba(0, 0, 0, 0)';
-
-function intoDatasets(
-  points, // array of original points, which contain payloads
-  data, // list of compressed coordinates
-  colors, // list of colors for each point to be displayed
-  sizes, // list of sizes for each point to be displayed
-  groupBy = null // payload field to group by
-) {
-  const defaultConfig = {
-    pointHitRadius: 1,
-    hoverRadius: 7,
-  };
-
-  if (!groupBy) {
-    // No grouping
-    return [
-      {
-        label: 'Data',
-        data,
-        offsets: Array.from({ length: data.length }, (_, i) => i),
-        pointBackgroundColor: [...colors],
-        // Use transparent border color for points
-        pointBorderColor: Array.from({ length: colors.length }, () => DEFAULT_BORDER_COLOR),
-        ...defaultConfig,
-      },
-    ];
-  }
-
-  const groups = {};
-
+function buildGroups(points, payloadField, colors) {
+  // Group points by payload value for the legend; group order is
+  // alphabetical, matching the previous Chart.js legend
+  const groupOfPoint = new Array(points.length);
+  const groups = new Map();
   points.forEach((point, index) => {
-    let group = get(point.payload, groupBy) + ''; // Convert to string, even if it's an o
-
-    if (!group) {
-      // If specified field is not present in the payload, fallback to 'Unknown'
-      group = 'Unknown';
+    let label = get(point.payload, payloadField) + '';
+    if (!label) {
+      label = 'Unknown';
     }
-
-    if (!groups[group]) {
-      groups[group] = {
-        label: group,
-        data: [],
-        offsets: [],
-        pointBackgroundColor: [],
-        pointBorderColor: [],
-        pointRadius: [],
-        ...defaultConfig,
-      };
+    if (!groups.has(label)) {
+      groups.set(label, { label, color: colors[index], pointIndices: [] });
     }
-
-    groups[group].data.push(data[index]);
-    groups[group].offsets.push(index);
-    groups[group].pointBackgroundColor.push(colors[index]);
-    groups[group].pointBorderColor.push(DEFAULT_BORDER_COLOR);
-    groups[group].pointRadius.push(sizes[index]);
+    groups.get(label).pointIndices.push(index);
+    groupOfPoint[index] = label;
   });
-
-  // Convert groups object to array, and sort by label
-  return Object.values(groups).sort((a, b) => a.label.localeCompare(b.label));
+  const sorted = [...groups.values()].sort((a, b) => a.label.localeCompare(b.label));
+  return { groups: sorted, groupOfPoint };
 }
 
 const VisualizeChart = ({
   requestResult, // Raw output of the request from qdrant client
   visualizationParams, // Parameters, as specified by the user in the input editor
-  activePoint, // currently selected point (with hover)
   setActivePoint, // callback to set new active point
 }) => {
   const { enqueueSnackbar } = useSnackbar();
-
-  // Id of the currently selected point
-  // Used to prevent multiple updates of the chart on hover
-  // And for switching colors of the selected point
-  let selectedPointLocation = null;
-
   const theme = useTheme();
 
-  function getSelectionColor() {
-    return theme.palette.mode === 'light' ? LIGHT_SELECTOR_COLOR : DARK_SELECTOR_COLOR;
-  }
+  const canvasRef = useRef(null);
+  const scatterRef = useRef(null);
+  const pointsRef = useRef([]);
+  const groupOfPointRef = useRef(null);
 
+  const [tooltip, setTooltip] = useState(null); // { x, y, id }
+  const [legendGroups, setLegendGroups] = useState(null);
+  const [hiddenGroups, setHiddenGroups] = useState(() => new Set());
+
+  // Create the WebGL renderer once per mount
   useEffect(() => {
-    if (!requestResult.points) {
+    let scatter;
+    try {
+      scatter = new ScatterGL(canvasRef.current, {
+        onHover: (index, x, y) => {
+          scatter.setHighlight(index);
+          if (index === null) {
+            setTooltip(null);
+            return;
+          }
+          const point = pointsRef.current[index];
+          setTooltip({ x, y, id: point?.id });
+          if (point && point.id !== undefined) {
+            setActivePoint(point);
+          }
+        },
+        onClick: (index) => {
+          const point = pointsRef.current[index];
+          if (point) {
+            setActivePoint(point);
+          }
+        },
+      });
+    } catch (e) {
+      enqueueSnackbar(`Visualization is not available: ${e.message}`, { variant: 'error' });
+      return undefined;
+    }
+    scatterRef.current = scatter;
+    return () => {
+      scatterRef.current = null;
+      scatter.destroy();
+    };
+  }, []);
+
+  // New request result: recolor, respawn the layout worker
+  useEffect(() => {
+    const scatter = scatterRef.current;
+    if (!requestResult.points || !scatter) {
       return;
     }
 
     const points = requestResult.points;
+    pointsRef.current = points;
+
     const colorBy = visualizationParams?.color_by;
-
-    // Initialize data with random points in range [0, 1]
-    const data = points.map(() => ({
-      x: Math.random(),
-      y: Math.random(),
-    }));
-
-    // This reference values should be used to rollback the color of the previously selected point
-    const pointColors = generateColorBy(points, colorBy);
-    const sizes = generateSizeBy(points);
-
+    const colors = generateColorBy(points, colorBy);
     const payloadField = typeof colorBy === 'string' ? colorBy : colorBy?.payload;
-    const useLegend = !!payloadField;
 
-    const datasets = intoDatasets(points, data, pointColors, sizes, payloadField);
+    scatter.setData(points.length);
+    scatter.setColors(colors);
 
-    const handlePointHover = (chart) => {
-      if (!chart.tooltip?._active) return;
-      if (chart.tooltip?._active.length === 0) return;
-
-      const lastActive = chart.tooltip._active.length - 1;
-
-      const selectedElement = chart.tooltip._active[lastActive];
-
-      const datasetIndex = selectedElement.datasetIndex;
-      const pointIndex = selectedElement.index;
-
-      const offsets = chart.data.datasets[datasetIndex].offsets;
-      const pointOffset = offsets[pointIndex];
-      const selectedPoint = points[pointOffset];
-
-      // Check if the same point is already selected
-      // To prevent recurrant updates of the chart
-      if (selectedPoint.id === activePoint?.id) {
-        selectedPointLocation = {
-          offset: pointOffset,
-          datasetIndex,
-          pointIndex,
-        };
-        return selectedPoint;
-      }
-      if (pointOffset === selectedPointLocation?.offset) {
-        return selectedPoint;
-      }
-
-      const oldPointLocation = selectedPointLocation;
-
-      selectedPointLocation = {
-        offset: pointOffset,
-        datasetIndex,
-        pointIndex,
-      };
-
-      // Reset color of the previously selected point
-      if (oldPointLocation) {
-        const targetColor = pointColors[oldPointLocation.offset];
-        chart.data.datasets[oldPointLocation.datasetIndex].pointBackgroundColor[oldPointLocation.pointIndex] =
-          targetColor;
-
-        chart.data.datasets[oldPointLocation.datasetIndex].pointBorderColor[oldPointLocation.pointIndex] =
-          DEFAULT_BORDER_COLOR;
-      }
-
-      chart.data.datasets[datasetIndex].pointBackgroundColor[pointIndex] = getSelectionColor();
-      chart.data.datasets[datasetIndex].pointBorderColor[pointIndex] = getSelectionColor();
-
-      setActivePoint(selectedPoint);
-
-      chart.update();
-      return selectedPoint;
-    };
-
-    const ctx = document.getElementById('myChart');
-    const myChart = new Chart(ctx, {
-      type: 'scatter',
-      data: {
-        datasets: datasets,
-      },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        scales: {
-          x: {
-            grid: {
-              display: false,
-            },
-            display: false,
-          },
-          y: {
-            display: false,
-          },
-        },
-        interaction: {
-          mode: 'nearest', // Show tooltip for the nearest point
-          intersect: false, // Show even if not directly hovering over a point
-        },
-        plugins: {
-          tooltip: {
-            // only use custom tooltip if color by is not discover score
-            enabled: true,
-            usePointStyle: true,
-            position: 'nearest',
-            intersect: true,
-            callbacks: {
-              label: (context) => {
-                const selectedPoint = handlePointHover(context.chart);
-                if (!selectedPoint) return '';
-                const id = selectedPoint.id;
-                return `Point ${id}`;
-              },
-            },
-          },
-          legend: {
-            display: useLegend,
-          },
-        },
-      },
-    });
+    if (payloadField) {
+      const { groups, groupOfPoint } = buildGroups(points, payloadField, colors);
+      groupOfPointRef.current = groupOfPoint;
+      setLegendGroups(groups);
+    } else {
+      groupOfPointRef.current = null;
+      setLegendGroups(null);
+    }
+    setHiddenGroups(new Set());
+    setTooltip(null);
 
     const worker = new Worker(new URL('./worker.js', import.meta.url), {
       type: 'module',
@@ -229,21 +117,13 @@ const VisualizeChart = ({
           variant: 'error',
         });
       } else if (m.data.result && m.data.result.length > 0) {
-        const reducedPonts = m.data.result;
-
-        const datasets = intoDatasets(points, reducedPonts, pointColors, sizes, payloadField);
-
-        datasets.forEach((dataset, index) => {
-          myChart.data.datasets[index].data = dataset.data;
-        });
-
-        myChart.update();
+        scatterRef.current?.updatePositions(m.data.result);
       } else {
         enqueueSnackbar(`Visualization Unsuccessful, error: Unexpected Error Occured`, { variant: 'error' });
       }
     };
 
-    if (requestResult.points?.length > 0) {
+    if (points.length > 0) {
       worker.postMessage({
         result: requestResult,
         params: visualizationParams,
@@ -251,15 +131,104 @@ const VisualizeChart = ({
     }
 
     return () => {
-      myChart.destroy();
       worker.terminate();
     };
   }, [requestResult]);
 
+  // Apply legend visibility toggles
+  useEffect(() => {
+    const scatter = scatterRef.current;
+    const groupOfPoint = groupOfPointRef.current;
+    if (!scatter || scatter.n === 0) {
+      return;
+    }
+    if (!groupOfPoint || hiddenGroups.size === 0) {
+      scatter.setVisibility(null);
+      return;
+    }
+    const visible = new Uint8Array(groupOfPoint.length);
+    for (let i = 0; i < groupOfPoint.length; i++) {
+      visible[i] = hiddenGroups.has(groupOfPoint[i]) ? 0 : 1;
+    }
+    scatter.setVisibility(visible);
+  }, [hiddenGroups, legendGroups]);
+
+  const toggleGroup = (label) => {
+    setHiddenGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(label)) {
+        next.delete(label);
+      } else {
+        next.add(label);
+      }
+      return next;
+    });
+  };
+
   return (
-    <>
-      <canvas id="myChart"></canvas>
-    </>
+    <Box sx={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden' }}>
+      {legendGroups && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            zIndex: 2,
+            display: 'flex',
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+            gap: 1.5,
+            px: 2,
+            py: 0.5,
+            pointerEvents: 'none',
+          }}
+        >
+          {legendGroups.map((group) => (
+            <Box
+              key={group.label}
+              onClick={() => toggleGroup(group.label)}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                cursor: 'pointer',
+                pointerEvents: 'auto',
+                opacity: hiddenGroups.has(group.label) ? 0.4 : 1,
+              }}
+            >
+              <Box sx={{ width: 20, height: 10, backgroundColor: group.color, borderRadius: '2px' }} />
+              <Typography
+                variant="caption"
+                sx={{ textDecoration: hiddenGroups.has(group.label) ? 'line-through' : 'none' }}
+              >
+                {group.label}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      )}
+      <canvas ref={canvasRef} style={{ width: '100%', height: '100%', display: 'block' }} />
+      {tooltip && (
+        <Box
+          sx={{
+            position: 'fixed',
+            left: tooltip.x + 12,
+            top: tooltip.y + 12,
+            zIndex: 3,
+            pointerEvents: 'none',
+            backgroundColor: theme.palette.background.paper,
+            border: `1px solid ${theme.palette.divider}`,
+            borderRadius: 1,
+            boxShadow: 2,
+            px: 1,
+            py: 0.25,
+          }}
+        >
+          <Typography variant="caption">Point {String(tooltip.id)}</Typography>
+        </Box>
+      )}
+    </Box>
   );
 };
 

--- a/src/components/VisualizeChart/index.jsx
+++ b/src/components/VisualizeChart/index.jsx
@@ -1,36 +1,21 @@
 import { useSnackbar } from 'notistack';
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Chip, Tooltip, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import get from 'lodash/get';
 import ScatterGL from './ScatterGL';
-import { generateColorBy } from './renderBy';
-
-function buildGroups(points, payloadField, colors) {
-  // Group points by payload value for the legend; group order is
-  // alphabetical, matching the previous Chart.js legend
-  const groupOfPoint = new Array(points.length);
-  const groups = new Map();
-  points.forEach((point, index) => {
-    let label = get(point.payload, payloadField) + '';
-    if (!label) {
-      label = 'Unknown';
-    }
-    if (!groups.has(label)) {
-      groups.set(label, { label, color: colors[index], pointIndices: [] });
-    }
-    groups.get(label).pointIndices.push(index);
-    groupOfPoint[index] = label;
-  });
-  const sorted = [...groups.values()].sort((a, b) => a.label.localeCompare(b.label));
-  return { groups: sorted, groupOfPoint };
-}
+import { generateColorBy, generateGroupsAndColors } from './renderBy';
 
 const VisualizeChart = ({
   requestResult, // Raw output of the request from qdrant client
   visualizationParams, // Parameters, as specified by the user in the input editor
-  setActivePoint, // callback to set new active point
+  fetching, // true while the distance-matrix request is in flight (before layout)
+  onPointSelect, // callback: point clicked (null for a click on empty space)
+  onBoxSelect, // callback: array of points selected with shift+drag
+  focusIds, // ids of points to emphasize (all others get dimmed), or null
+  selectedId, // id of the single clicked point, marked distinctly, or null
+  selectionCount, // number of points in the active selection, if any
+  onSelectionClear, // callback: the selection chip was closed
 }) => {
   const { enqueueSnackbar } = useSnackbar();
   const theme = useTheme();
@@ -39,10 +24,22 @@ const VisualizeChart = ({
   const scatterRef = useRef(null);
   const pointsRef = useRef([]);
   const groupOfPointRef = useRef(null);
+  // Callbacks are captured by ScatterGL once at mount, keep them fresh
+  const callbacksRef = useRef({});
+  callbacksRef.current = { onPointSelect, onBoxSelect };
 
   const [tooltip, setTooltip] = useState(null); // { x, y, id }
   const [legendGroups, setLegendGroups] = useState(null);
   const [hiddenGroups, setHiddenGroups] = useState(() => new Set());
+  const [boxRect, setBoxRect] = useState(null);
+  const [progress, setProgress] = useState(null); // { step, total } while the layout runs
+  const workerRef = useRef(null);
+
+  const stopLayout = () => {
+    workerRef.current?.terminate();
+    workerRef.current = null;
+    setProgress(null);
+  };
 
   // Create the WebGL renderer once per mount
   useEffect(() => {
@@ -57,16 +54,16 @@ const VisualizeChart = ({
           }
           const point = pointsRef.current[index];
           setTooltip({ x, y, id: point?.id });
-          if (point && point.id !== undefined) {
-            setActivePoint(point);
-          }
         },
         onClick: (index) => {
-          const point = pointsRef.current[index];
-          if (point) {
-            setActivePoint(point);
-          }
+          const point = index === null ? null : pointsRef.current[index];
+          callbacksRef.current.onPointSelect?.(point ?? null);
         },
+        onBoxSelect: (indices) => {
+          const points = indices.map((index) => pointsRef.current[index]).filter(Boolean);
+          callbacksRef.current.onBoxSelect?.(points);
+        },
+        onBoxRect: (rect) => setBoxRect(rect),
       });
     } catch (e) {
       enqueueSnackbar(`Visualization is not available: ${e.message}`, { variant: 'error' });
@@ -90,17 +87,17 @@ const VisualizeChart = ({
     pointsRef.current = points;
 
     const colorBy = visualizationParams?.color_by;
-    const colors = generateColorBy(points, colorBy);
     const payloadField = typeof colorBy === 'string' ? colorBy : colorBy?.payload;
 
     scatter.setData(points.length);
-    scatter.setColors(colors);
 
     if (payloadField) {
-      const { groups, groupOfPoint } = buildGroups(points, payloadField, colors);
+      const { colors, groups, groupOfPoint } = generateGroupsAndColors(points, payloadField);
+      scatter.setColors(colors);
       groupOfPointRef.current = groupOfPoint;
       setLegendGroups(groups);
     } else {
+      scatter.setColors(generateColorBy(points, colorBy));
       groupOfPointRef.current = null;
       setLegendGroups(null);
     }
@@ -110,16 +107,24 @@ const VisualizeChart = ({
     const worker = new Worker(new URL('./worker.js', import.meta.url), {
       type: 'module',
     });
+    workerRef.current = worker;
 
     worker.onmessage = (m) => {
       if (m.data.error) {
+        setProgress(null);
         enqueueSnackbar(`Visualization Unsuccessful, error: ${m.data.error}`, {
           variant: 'error',
         });
       } else if (m.data.result && m.data.result.length > 0) {
         scatterRef.current?.updatePositions(m.data.result);
+        if (m.data.done) {
+          setProgress(null);
+        } else if (m.data.progress) {
+          setProgress(m.data.progress);
+        }
       } else {
-        enqueueSnackbar(`Visualization Unsuccessful, error: Unexpected Error Occured`, { variant: 'error' });
+        setProgress(null);
+        enqueueSnackbar(`Visualization Unsuccessful, error: Unexpected Error Occurred`, { variant: 'error' });
       }
     };
 
@@ -128,10 +133,13 @@ const VisualizeChart = ({
         result: requestResult,
         params: visualizationParams,
       });
+      setProgress({ step: 0, total: null });
     }
 
     return () => {
       worker.terminate();
+      workerRef.current = null;
+      setProgress(null);
     };
   }, [requestResult]);
 
@@ -152,6 +160,41 @@ const VisualizeChart = ({
     }
     scatter.setVisibility(visible);
   }, [hiddenGroups, legendGroups]);
+
+  // Emphasize the given point ids (nearest neighbors of a selection or
+  // a highlight filter match) by dimming everything else
+  useEffect(() => {
+    const scatter = scatterRef.current;
+    if (!scatter || scatter.n === 0) {
+      return;
+    }
+    if (!focusIds || focusIds.length === 0) {
+      scatter.setFocus(null);
+      return;
+    }
+    const idSet = new Set(focusIds.map((id) => String(id)));
+    const indices = [];
+    pointsRef.current.forEach((point, index) => {
+      if (idSet.has(String(point.id))) {
+        indices.push(index);
+      }
+    });
+    scatter.setFocus(indices);
+  }, [focusIds, requestResult]);
+
+  // Mark the single clicked point distinctly from its highlighted neighbors
+  useEffect(() => {
+    const scatter = scatterRef.current;
+    if (!scatter || scatter.n === 0) {
+      return;
+    }
+    if (selectedId === null || selectedId === undefined) {
+      scatter.setSelected(null, theme.palette.text.primary);
+      return;
+    }
+    const index = pointsRef.current.findIndex((point) => String(point.id) === String(selectedId));
+    scatter.setSelected(index >= 0 ? index : null, theme.palette.text.primary);
+  }, [selectedId, requestResult, theme.palette.text.primary]);
 
   const toggleGroup = (label) => {
     setHiddenGroups((prev) => {
@@ -203,12 +246,65 @@ const VisualizeChart = ({
                 sx={{ textDecoration: hiddenGroups.has(group.label) ? 'line-through' : 'none' }}
               >
                 {group.label}
+                {typeof group.count === 'number' ? ` (${group.count})` : ''}
               </Typography>
             </Box>
           ))}
         </Box>
       )}
+      {selectionCount > 0 && (
+        <Chip
+          size="small"
+          color="primary"
+          label={`${selectionCount} points selected`}
+          onDelete={onSelectionClear}
+          sx={{ position: 'absolute', bottom: 8, right: 8, zIndex: 2 }}
+        />
+      )}
+      {/* Fetching takes precedence over any stale progress from the previous
+          run's worker, which keeps animating until the new result arrives */}
+      {fetching ? (
+        <Tooltip title="Requesting data from Qdrant, this can take a while on the first request">
+          <Chip
+            size="small"
+            variant="outlined"
+            label="Requesting data…"
+            sx={{ position: 'absolute', bottom: 8, left: 8, zIndex: 2, backdropFilter: 'blur(2px)' }}
+          />
+        </Tooltip>
+      ) : (
+        progress && (
+          <Tooltip title="Layout is running, press to stop it and keep the current picture">
+            <Chip
+              size="small"
+              variant="outlined"
+              label={
+                progress.total
+                  ? `Layout: ${Math.round((progress.step / progress.total) * 100)}%`
+                  : `Layout: iteration ${progress.step}`
+              }
+              onDelete={stopLayout}
+              sx={{ position: 'absolute', bottom: 8, left: 8, zIndex: 2, backdropFilter: 'blur(2px)' }}
+            />
+          </Tooltip>
+        )
+      )}
       <canvas ref={canvasRef} style={{ width: '100%', height: '100%', display: 'block' }} />
+      {boxRect && (
+        <Box
+          sx={{
+            position: 'absolute',
+            left: boxRect.left,
+            top: boxRect.top,
+            width: boxRect.width,
+            height: boxRect.height,
+            border: `1px dashed ${theme.palette.primary.main}`,
+            backgroundColor: 'rgba(128, 128, 255, 0.1)',
+            pointerEvents: 'none',
+            zIndex: 2,
+          }}
+        />
+      )}
       {tooltip && (
         <Box
           sx={{
@@ -235,8 +331,13 @@ const VisualizeChart = ({
 VisualizeChart.propTypes = {
   requestResult: PropTypes.object.isRequired,
   visualizationParams: PropTypes.object.isRequired,
-  activePoint: PropTypes.object,
-  setActivePoint: PropTypes.func,
+  fetching: PropTypes.bool,
+  onPointSelect: PropTypes.func,
+  onBoxSelect: PropTypes.func,
+  focusIds: PropTypes.array,
+  selectedId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  selectionCount: PropTypes.number,
+  onSelectionClear: PropTypes.func,
 };
 
 export default VisualizeChart;

--- a/src/components/VisualizeChart/pca.js
+++ b/src/components/VisualizeChart/pca.js
@@ -1,0 +1,103 @@
+// Principal component analysis, used by the visualization worker for the
+// 'PCA' algorithm - the one path that still consumes raw vectors.
+
+// Deterministic PRNG for reproducible PCA sign/orientation
+function mulberry32(seed) {
+  let a = seed;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Project onto the top-2 principal components via power iteration on the
+// centered data. Never forms the covariance matrix: each iteration is
+// w = X_c^T (X_c v), O(n * d)
+export function pca2d(vectors) {
+  const n = vectors.length;
+  const d = vectors[0].length;
+
+  const mean = new Float64Array(d);
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < d; j++) {
+      mean[j] += vectors[i][j];
+    }
+  }
+  for (let j = 0; j < d; j++) {
+    mean[j] /= n;
+  }
+
+  const rand = mulberry32(42);
+  const components = [];
+
+  for (let c = 0; c < 2; c++) {
+    let v = new Float64Array(d);
+    for (let j = 0; j < d; j++) {
+      v[j] = rand() - 0.5;
+    }
+    orthonormalize(v, components);
+
+    for (let iter = 0; iter < 64; iter++) {
+      const w = new Float64Array(d);
+      for (let i = 0; i < n; i++) {
+        const row = vectors[i];
+        let dot = 0;
+        for (let j = 0; j < d; j++) {
+          dot += (row[j] - mean[j]) * v[j];
+        }
+        for (let j = 0; j < d; j++) {
+          w[j] += (row[j] - mean[j]) * dot;
+        }
+      }
+      orthonormalize(w, components);
+
+      let agreement = 0;
+      for (let j = 0; j < d; j++) {
+        agreement += w[j] * v[j];
+      }
+      v = w;
+      if (Math.abs(1 - Math.abs(agreement)) < 1e-9) {
+        break;
+      }
+    }
+    components.push(v);
+  }
+
+  const positions = new Float32Array(n * 2);
+  for (let i = 0; i < n; i++) {
+    const row = vectors[i];
+    for (let c = 0; c < 2; c++) {
+      let dot = 0;
+      for (let j = 0; j < d; j++) {
+        dot += (row[j] - mean[j]) * components[c][j];
+      }
+      positions[i * 2 + c] = dot;
+    }
+  }
+  return positions;
+}
+
+// Remove projections onto previous components, then normalize
+function orthonormalize(v, components) {
+  const d = v.length;
+  for (const component of components) {
+    let dot = 0;
+    for (let j = 0; j < d; j++) {
+      dot += v[j] * component[j];
+    }
+    for (let j = 0; j < d; j++) {
+      v[j] -= dot * component[j];
+    }
+  }
+  let norm = 0;
+  for (let j = 0; j < d; j++) {
+    norm += v[j] * v[j];
+  }
+  norm = Math.sqrt(norm) || 1;
+  for (let j = 0; j < d; j++) {
+    v[j] /= norm;
+  }
+}

--- a/src/components/VisualizeChart/renderBy.js
+++ b/src/components/VisualizeChart/renderBy.js
@@ -28,6 +28,50 @@ const PALLETE = [
 
 // const SELECTED_BORDER_COLOR = '#881177';
 
+// Payload fields with many distinct values would produce an unreadable
+// legend and an undecipherable coloring: only the largest categories get
+// their own color, the rest is merged into "Other"
+export const MAX_LEGEND_GROUPS = 10;
+export const OTHER_GROUP_LABEL = 'Other';
+const OTHER_GROUP_COLOR = '#9E9E9E';
+
+function getNestedValue(obj, path) {
+  return path.split('.').reduce((acc, part) => acc && acc[part], obj);
+}
+
+// Group points by a payload field, keeping individual colors for the
+// MAX_LEGEND_GROUPS largest categories and merging the rest into "Other".
+// Returns { colors, groups, groupOfPoint }:
+// - colors: per-point CSS color
+// - groups: [{ label, color, count }], largest first, "Other" last
+// - groupOfPoint: per-point group label
+export function generateGroupsAndColors(points, payloadField) {
+  const values = points.map((point) => {
+    const value = getNestedValue(point.payload, payloadField);
+    return value === undefined || value === null || value === '' ? 'Unknown' : String(value);
+  });
+
+  const counts = new Map();
+  for (const value of values) {
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  const top = sorted.slice(0, MAX_LEGEND_GROUPS);
+
+  const colorOf = new Map(top.map(([value], index) => [value, PALLETE[index % PALLETE.length]]));
+  const groups = top.map(([value, count]) => ({ label: value, color: colorOf.get(value), count }));
+
+  if (sorted.length > MAX_LEGEND_GROUPS) {
+    const otherCount = sorted.slice(MAX_LEGEND_GROUPS).reduce((sum, [, count]) => sum + count, 0);
+    groups.push({ label: OTHER_GROUP_LABEL, color: OTHER_GROUP_COLOR, count: otherCount });
+  }
+
+  const groupOfPoint = values.map((value) => (colorOf.has(value) ? value : OTHER_GROUP_LABEL));
+  const colors = groupOfPoint.map((label) => (label === OTHER_GROUP_LABEL ? OTHER_GROUP_COLOR : colorOf.get(label)));
+
+  return { colors, groups, groupOfPoint };
+}
+
 function colorByPayload(payloadValue, colored) {
   if (colored[payloadValue]) {
     return colored[payloadValue];
@@ -64,10 +108,6 @@ export function generateColorBy(points, colorBy = null) {
   // If `colorBy` is a string, interpret as a field name
   if (typeof colorBy === 'string') {
     colorBy = { payload: colorBy };
-  }
-
-  function getNestedValue(obj, path) {
-    return path.split('.').reduce((acc, part) => acc && acc[part], obj);
   }
 
   if (colorBy.payload) {

--- a/src/components/VisualizeChart/renderBy.js
+++ b/src/components/VisualizeChart/renderBy.js
@@ -81,8 +81,13 @@ export function generateColorBy(points, colorBy = null) {
 
   if (colorBy.query) {
     const scores = points.map((point) => point.score);
-    const minScore = Math.min(...scores);
-    const maxScore = Math.max(...scores);
+    // No Math.min(...scores): spreading large arrays overflows the call stack
+    let minScore = Infinity;
+    let maxScore = -Infinity;
+    for (const score of scores) {
+      if (score < minScore) minScore = score;
+      if (score > maxScore) maxScore = score;
+    }
 
     const colorScale = chroma.scale(SCORE_GRADIENT_COLORS);
     return scores.map((score) => {

--- a/src/components/VisualizeChart/requestData.js
+++ b/src/components/VisualizeChart/requestData.js
@@ -1,41 +1,36 @@
 /* eslint-disable camelcase */
 import { DEFAULT_N_NEIGHBORS, resolveDistanceMetric } from '../../lib/knn-graph';
 
-// Preferred data source: server-side distance matrix (Qdrant >= 1.12).
-// Qdrant samples `limit` points and computes a knn graph between them,
-// so raw vectors never have to be transferred to the browser.
-// Falls back to the legacy scroll-with-vectors request for older servers
-// and for PCA, which needs the raw vectors.
+// Data source for the visualization: the server-side distance matrix
+// (Qdrant >= 1.12). Qdrant samples `limit` points and computes a knn graph
+// between them, so raw vectors never have to be transferred to the browser.
+//
+// The one exception is PCA, which fundamentally needs the raw vectors and
+// is fed by a plain scroll request.
 
 export async function requestData(qdrantClient, collectionName, params) {
-  const { algorithm = null } = params;
-
-  if (algorithm === 'PCA') {
-    // PCA operates on raw vectors, there is nothing to precompute server-side
+  if (params.algorithm === 'PCA') {
     return await requestRawVectors(qdrantClient, collectionName, params);
   }
-
-  try {
-    return await requestMatrixData(qdrantClient, collectionName, params);
-  } catch (e) {
-    if (isMatrixApiUnsupported(e)) {
-      // Qdrant < 1.12 does not have the distance matrix API
-      return await requestRawVectors(qdrantClient, collectionName, params);
-    }
-    throw e;
-  }
+  return await requestMatrixData(qdrantClient, collectionName, params);
 }
 
 async function requestMatrixData(
   qdrantClient,
   collectionName,
-  { limit, filter = null, using = null, color_by = null, n_neighbors = null }
+  { limit, filter = null, using = null, color_by = null, n_neighbors = null, perplexity = null, highlight = null }
 ) {
+  // t-SNE convention: the Gaussian kernel wants ~3x perplexity neighbors
+  let knnLimit = n_neighbors ?? DEFAULT_N_NEIGHBORS;
+  if (perplexity != null) {
+    knnLimit = Math.max(knnLimit, Math.ceil(3 * perplexity));
+  }
+
   const [collectionInfo, matrixResponse] = await Promise.all([
     qdrantClient.getCollection(collectionName),
     qdrantClient.searchMatrixOffsets(collectionName, {
       sample: limit,
-      limit: n_neighbors ?? DEFAULT_N_NEIGHBORS,
+      limit: knnLimit,
       filter,
       using: using ?? undefined,
     }),
@@ -92,29 +87,43 @@ async function requestMatrixData(
   // of the knn graph refer to positions in the `ids` array
   const points = ids.map((id) => pointById.get(String(id)) ?? { id, payload: {} });
 
+  // 'highlight': emphasize sampled points matching an extra filter,
+  // evaluated server-side against the sampled ids only
+  let highlightIds = null;
+  if (highlight?.filter) {
+    const { points: matched } = await qdrantClient.scroll(collectionName, {
+      filter: { must: [highlight.filter, { has_id: ids }] },
+      limit: ids.length,
+      with_payload: false,
+      with_vector: false,
+    });
+    highlightIds = matched.map((point) => point.id);
+  }
+
   return {
     points,
     graph: matrixResponse,
     metric: resolveDistanceMetric(collectionInfo, using),
+    highlightIds,
   };
 }
 
+// Raw vectors, PCA only
 async function requestRawVectors(
   qdrantClient,
   collectionName,
   { limit, filter = null, using = null, color_by = null }
 ) {
-  if (color_by?.query) {
-    const query = {
+  if (color_by != null && color_by.query !== undefined && color_by.query !== null) {
+    // Score-based coloring: the query provides both vectors and scores
+    return await qdrantClient.query(collectionName, {
       query: color_by.query,
       limit: limit,
       filter: filter,
       with_vector: using ? [using] : true,
       with_payload: true,
-      using: using ?? null,
-    };
-
-    return await qdrantClient.query(collectionName, query);
+      using: using ?? undefined,
+    });
   }
 
   const scrollQuery = {
@@ -125,12 +134,4 @@ async function requestRawVectors(
   };
 
   return await qdrantClient.scroll(collectionName, scrollQuery);
-}
-
-function isMatrixApiUnsupported(error) {
-  const status = error?.status ?? error?.response?.status;
-  if (status === 404 || status === 501) {
-    return true;
-  }
-  return /not found/i.test(String(error?.message ?? ''));
 }

--- a/src/components/VisualizeChart/tests/pca.test.js
+++ b/src/components/VisualizeChart/tests/pca.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { pca2d } from '../pca';
+
+describe('pca2d', () => {
+  it('projects onto the directions of maximal variance', () => {
+    // Points on a diagonal line in 3D with small orthogonal noise:
+    // the first component must capture the diagonal
+    const points = [];
+    for (let i = 0; i < 50; i++) {
+      const t = i - 25;
+      points.push([t, t, t + Math.sin(i * 7.3) * 0.01]);
+    }
+    const projected = pca2d(points);
+
+    // Order along the first component matches order along the line
+    // (up to a global sign)
+    const xs = [];
+    for (let i = 0; i < 50; i++) {
+      xs.push(projected[i * 2]);
+    }
+    const increasing = xs.every((x, i) => i === 0 || x > xs[i - 1]);
+    const decreasing = xs.every((x, i) => i === 0 || x < xs[i - 1]);
+    expect(increasing || decreasing).toBe(true);
+
+    // Second component only carries the noise
+    const spreadY =
+      Math.max(...xs.map((_, i) => projected[i * 2 + 1])) - Math.min(...xs.map((_, i) => projected[i * 2 + 1]));
+    const spreadX = Math.max(...xs) - Math.min(...xs);
+    expect(spreadY).toBeLessThan(spreadX / 10);
+  });
+
+  it('separates two clusters along the first component', () => {
+    const points = [];
+    for (let i = 0; i < 40; i++) {
+      const offset = i < 20 ? 0 : 8;
+      points.push([offset + Math.sin(i) * 0.3, offset + Math.cos(i) * 0.3, Math.sin(i * 2) * 0.3]);
+    }
+    const projected = pca2d(points);
+    const a = projected.filter((_, idx) => idx % 2 === 0).slice(0, 20);
+    const b = projected.filter((_, idx) => idx % 2 === 0).slice(20);
+    const meanA = a.reduce((s, v) => s + v, 0) / a.length;
+    const meanB = b.reduce((s, v) => s + v, 0) / b.length;
+    expect(Math.abs(meanA - meanB)).toBeGreaterThan(5);
+  });
+
+  it('is deterministic', () => {
+    const points = Array.from({ length: 30 }, (_, i) => [Math.sin(i * 1.7), Math.cos(i * 0.9), Math.sin(i * 2.3)]);
+    expect(pca2d(points)).toEqual(pca2d(points));
+  });
+});

--- a/src/components/VisualizeChart/worker.js
+++ b/src/components/VisualizeChart/worker.js
@@ -1,13 +1,9 @@
 /* eslint-disable no-restricted-globals */
-import * as druid from '@saehrimnir/druidjs';
 import get from 'lodash/get';
-import initWasm, { UmapLayout } from '@qdrant/graph-layout-wasm';
+import initWasm, { UmapLayout, TsneLayout, TsneParams } from '@qdrant/graph-layout-wasm';
 import wasmUrl from '@qdrant/graph-layout-wasm/pkg/graph_layout_wasm_bg.wasm?url';
-import { densifyKnnGraph, scoresToDistances } from '../../lib/knn-graph';
-
-// druid's TSNE with `metric: "precomputed"` references the bare name `druid`
-// inside its own bundle (upstream bug), so the module has to be exposed globally
-self.druid = druid;
+import { scoresToDistances } from '../../lib/knn-graph';
+import { pca2d } from './pca';
 
 let wasmReady = null;
 function ensureWasm() {
@@ -17,23 +13,8 @@ function ensureWasm() {
 
 const MESSAGE_INTERVAL = 200;
 const UMAP_EPOCHS_PER_CHUNK = 5;
+const TSNE_ITERATIONS_PER_CHUNK = 10;
 const DEFAULT_ALGORITHM = 'UMAP';
-
-function getVectorType(vector) {
-  if (Array.isArray(vector)) {
-    if (Array.isArray(vector[0])) {
-      return 'multivector';
-    }
-    return 'vector';
-  }
-  if (typeof vector === 'object') {
-    if (vector.indices) {
-      return 'sparse';
-    }
-    return 'named';
-  }
-  return 'unknown';
-}
 
 self.onmessage = async function (e) {
   const params = e?.data?.params || {};
@@ -42,8 +23,10 @@ self.onmessage = async function (e) {
   try {
     if (result.graph) {
       await handleKnnGraph(result, params);
+    } else if ((params.algorithm || DEFAULT_ALGORITHM) === 'PCA') {
+      handlePca(result, params);
     } else {
-      handleRawVectors(result, params);
+      self.postMessage({ data: [], error: 'No data found' });
     }
   } catch (error) {
     self.postMessage({ data: [], error: error?.message ?? String(error) });
@@ -70,78 +53,87 @@ async function handleKnnGraph(result, params) {
     return;
   }
 
-  if (algorithm === 'UMAP') {
-    // wasm layout consumes the sparse knn graph directly, no densification
-    await ensureWasm();
-    const distances = scoresToDistances(graph.scores, result.metric);
-    const layout = new UmapLayout(
-      n,
-      new Uint32Array(graph.offsets_row),
-      new Uint32Array(graph.offsets_col),
-      new Float32Array(distances),
-      undefined // default params: min_dist 0.1, auto epochs, fixed seed
-    );
+  await ensureWasm();
 
-    try {
-      let now = Date.now();
-      let done = false;
-      while (!done) {
-        done = layout.step(UMAP_EPOCHS_PER_CHUNK);
-        if (Date.now() - now > MESSAGE_INTERVAL) {
-          now = Date.now();
-          postPositions(layout.embedding());
-        }
-      }
-      postPositions(layout.embedding());
-    } finally {
-      layout.free();
-    }
+  const rows = new Uint32Array(graph.offsets_row);
+  const cols = new Uint32Array(graph.offsets_col);
+  const distances = new Float32Array(scoresToDistances(graph.scores, result.metric));
+
+  let layout;
+  let chunk;
+  if (algorithm === 'UMAP') {
+    // default params: min_dist 0.1, auto epochs, fixed seed
+    layout = new UmapLayout(n, rows, cols, distances, undefined);
+    chunk = UMAP_EPOCHS_PER_CHUNK;
   } else if (algorithm === 'TSNE') {
-    // druid's TSNE defaults to squared euclidean, mirror that for precomputed distances
-    const matrix = densifyKnnGraph(graph, result.metric, { squared: true });
-    const perplexity = Math.max(2, Math.min(50, Math.floor((n - 1) / 3)));
-    const reducer = new druid.TSNE(matrix, { metric: 'precomputed', perplexity });
-    streamLayout(reducer);
+    const tsneParams = new TsneParams();
+    // The graph carries the neighbors the server was asked for; without an
+    // explicit perplexity, derive one from the actual graph degree
+    // (t-SNE convention: k = 3 x perplexity)
+    const avgDegree = Math.floor(graph.scores.length / n);
+    tsneParams.perplexity = params.perplexity ?? Math.min(30, Math.max(2, Math.floor(avgDegree / 3)));
+    layout = new TsneLayout(n, rows, cols, distances, tsneParams);
+    chunk = TSNE_ITERATIONS_PER_CHUNK;
   } else {
     self.postMessage({
       data: [],
       error: `${algorithm} does not support server-side distance matrix`,
     });
+    return;
+  }
+
+  try {
+    let now = Date.now();
+    let done = false;
+    while (!done) {
+      done = layout.step(chunk);
+      if (Date.now() - now > MESSAGE_INTERVAL) {
+        now = Date.now();
+        postPositions(layout.embedding(), {
+          step: layout.current_epoch(),
+          total: layout.n_epochs(),
+        });
+      }
+    }
+    postPositions(layout.embedding(), null, true);
+  } finally {
+    layout.free();
   }
 }
 
-// Send flat [x0, y0, x1, y1, ...] coordinates, transferring the buffer
-function postPositions(positions) {
-  const array = positions instanceof Float32Array ? positions : new Float32Array(positions);
-  self.postMessage({ result: array, error: null }, [array.buffer]);
+function getVectorType(vector) {
+  if (Array.isArray(vector)) {
+    if (Array.isArray(vector[0])) {
+      return 'multivector';
+    }
+    return 'vector';
+  }
+  if (typeof vector === 'object') {
+    if (vector.indices) {
+      return 'sparse';
+    }
+    return 'named';
+  }
+  return 'unknown';
 }
 
-// Legacy path: dimensionality reduction on raw vectors, loaded into the browser.
-// Used for PCA and as a fallback for Qdrant versions without the matrix API.
-function handleRawVectors(result, params) {
-  const algorithm = params.algorithm || DEFAULT_ALGORITHM;
-
-  const data = [];
-
+// PCA fundamentally needs the raw vectors (there is nothing to precompute
+// server-side), so it is the one algorithm still fed by a scroll request
+function handlePca(result, params) {
   const points = result.points;
   const vectorName = params.using;
 
   if (!points || points.length === 0) {
-    self.postMessage({
-      data: [],
-      error: 'No data found',
-    });
+    self.postMessage({ data: [], error: 'No data found' });
     return;
   }
 
   if (points.length === 1) {
-    self.postMessage({
-      data: [],
-      error: `cannot perform ${algorithm} on single point`,
-    });
+    self.postMessage({ data: [], error: 'cannot perform PCA on single point' });
     return;
   }
 
+  const data = [];
   for (let i = 0; i < points.length; i++) {
     if (!vectorName) {
       // Work with default vector
@@ -152,16 +144,11 @@ function handleRawVectors(result, params) {
     }
   }
 
-  // Validate data
-
   for (let i = 0; i < data.length; i++) {
-    const vector = data[i];
-    const vectorType = getVectorType(vector);
-
+    const vectorType = getVectorType(data[i]);
     if (vectorType === 'vector') {
       continue;
     }
-
     if (vectorType === 'named') {
       self.postMessage({
         data: [],
@@ -169,7 +156,6 @@ function handleRawVectors(result, params) {
       });
       return;
     }
-
     self.postMessage({
       data: [],
       error: 'Vector visualization is not supported for vector type: ' + vectorType,
@@ -177,40 +163,12 @@ function handleRawVectors(result, params) {
     return;
   }
 
-  if (data.length) {
-    if (algorithm === 'PCA') {
-      const D = new druid[algorithm](data, {});
-      const transformedData = D.transform();
-
-      postPositions(flatten(transformedData));
-    } else {
-      const D = new druid[algorithm](data, {}); // ex  params = { perplexity : 50,epsilon :5}
-      streamLayout(D);
-    }
-  }
+  postPositions(pca2d(data), null, true);
 }
 
-// Run the iterative layout, streaming intermediate results for animation
-function streamLayout(reducer) {
-  let now = Date.now();
-  const next = reducer.generator(); // default = 500 iterations
-
-  let reducedPoints = [];
-  for (reducedPoints of next) {
-    if (Date.now() - now > MESSAGE_INTERVAL) {
-      now = Date.now();
-      postPositions(flatten(reducedPoints));
-    }
-  }
-  postPositions(flatten(reducedPoints));
-}
-
-// Convert [[x1, y1], [x2, y2], ...] to flat [x1, y1, x2, y2, ...]
-function flatten(reducedPoints) {
-  const flat = new Float32Array(reducedPoints.length * 2);
-  for (let i = 0; i < reducedPoints.length; i++) {
-    flat[i * 2] = reducedPoints[i][0];
-    flat[i * 2 + 1] = reducedPoints[i][1];
-  }
-  return flat;
+// Send flat [x0, y0, x1, y1, ...] coordinates, transferring the buffer.
+// `progress` is { step, total }, `done` marks the final frame of the layout.
+function postPositions(positions, progress = null, done = false) {
+  const array = positions instanceof Float32Array ? positions : new Float32Array(positions);
+  self.postMessage({ result: array, progress, done, error: null }, [array.buffer]);
 }

--- a/src/components/VisualizeChart/worker.js
+++ b/src/components/VisualizeChart/worker.js
@@ -89,10 +89,10 @@ async function handleKnnGraph(result, params) {
         done = layout.step(UMAP_EPOCHS_PER_CHUNK);
         if (Date.now() - now > MESSAGE_INTERVAL) {
           now = Date.now();
-          self.postMessage({ result: intoPointsDataset(layout.embedding()), error: null });
+          postPositions(layout.embedding());
         }
       }
-      self.postMessage({ result: intoPointsDataset(layout.embedding()), error: null });
+      postPositions(layout.embedding());
     } finally {
       layout.free();
     }
@@ -110,13 +110,10 @@ async function handleKnnGraph(result, params) {
   }
 }
 
-function intoPointsDataset(embedding) {
-  // Flat [x0, y0, x1, y1, ...] to [ { x: x0, y: y0 }, ... ]
-  const points = new Array(embedding.length / 2);
-  for (let i = 0; i < points.length; i++) {
-    points[i] = { x: embedding[i * 2], y: embedding[i * 2 + 1] };
-  }
-  return points;
+// Send flat [x0, y0, x1, y1, ...] coordinates, transferring the buffer
+function postPositions(positions) {
+  const array = positions instanceof Float32Array ? positions : new Float32Array(positions);
+  self.postMessage({ result: array, error: null }, [array.buffer]);
 }
 
 // Legacy path: dimensionality reduction on raw vectors, loaded into the browser.
@@ -185,7 +182,7 @@ function handleRawVectors(result, params) {
       const D = new druid[algorithm](data, {});
       const transformedData = D.transform();
 
-      self.postMessage({ result: getDataset(transformedData), error: null });
+      postPositions(flatten(transformedData));
     } else {
       const D = new druid[algorithm](data, {}); // ex  params = { perplexity : 50,epsilon :5}
       streamLayout(D);
@@ -202,13 +199,18 @@ function streamLayout(reducer) {
   for (reducedPoints of next) {
     if (Date.now() - now > MESSAGE_INTERVAL) {
       now = Date.now();
-      self.postMessage({ result: getDataset(reducedPoints), error: null });
+      postPositions(flatten(reducedPoints));
     }
   }
-  self.postMessage({ result: getDataset(reducedPoints), error: null });
+  postPositions(flatten(reducedPoints));
 }
 
-function getDataset(reducedPoints) {
-  // Convert [[x1, y1], [x2, y2] ] to [ { x: x1, y: y1 }, { x: x2, y: y2 } ]
-  return reducedPoints.map((point) => ({ x: point[0], y: point[1] }));
+// Convert [[x1, y1], [x2, y2], ...] to flat [x1, y1, x2, y2, ...]
+function flatten(reducedPoints) {
+  const flat = new Float32Array(reducedPoints.length * 2);
+  for (let i = 0; i < reducedPoints.length; i++) {
+    flat[i * 2] = reducedPoints[i][0];
+    flat[i * 2 + 1] = reducedPoints[i][1];
+  }
+  return flat;
 }

--- a/src/lib/knn-graph.js
+++ b/src/lib/knn-graph.js
@@ -38,48 +38,6 @@ export function scoresToDistances(scores, metric) {
   }
 }
 
-// Expand the sparse knn graph from the matrix/offsets response into a dense,
-// symmetric distance matrix (as an array of rows), suitable for DruidJS
-// with `metric: "precomputed"`. Pairs absent from the knn graph get a penalty
-// distance larger than any observed one.
-//
-// Note: this densification is O(n²) memory and is a temporary bridge until
-// the layout can consume the sparse graph directly.
-export function densifyKnnGraph(graph, metric, { squared = false } = {}) {
-  const { offsets_row, offsets_col, scores, ids } = graph;
-  const n = ids.length;
-
-  const distances = scoresToDistances(scores, metric);
-
-  const maxDistance = distances.length > 0 ? arrayMax(distances) : 0;
-  let fillValue = (maxDistance > 0 ? maxDistance : 1) * 2;
-  if (squared) {
-    fillValue *= fillValue;
-  }
-
-  const matrix = new Array(n);
-  for (let i = 0; i < n; i++) {
-    matrix[i] = new Array(n).fill(fillValue);
-    matrix[i][i] = 0;
-  }
-
-  for (let k = 0; k < distances.length; k++) {
-    const i = offsets_row[k];
-    const j = offsets_col[k];
-    if (i === j) {
-      continue;
-    }
-    const distance = squared ? distances[k] * distances[k] : distances[k];
-    // Symmetrize, keeping the smaller distance if both directions are present
-    if (distance < matrix[i][j]) {
-      matrix[i][j] = distance;
-      matrix[j][i] = distance;
-    }
-  }
-
-  return matrix;
-}
-
 // Figure out the distance metric of the vector used for visualization
 // from the collection info. Returns null if it cannot be determined.
 export function resolveDistanceMetric(collectionInfo, using = null) {

--- a/src/lib/tests/knn-graph.test.js
+++ b/src/lib/tests/knn-graph.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { describe, it, expect } from 'vitest';
-import { scoresToDistances, densifyKnnGraph, resolveDistanceMetric } from '../knn-graph';
+import { scoresToDistances, resolveDistanceMetric } from '../knn-graph';
 
 describe('scoresToDistances', () => {
   it('converts cosine similarity to distance', () => {
@@ -22,66 +22,6 @@ describe('scoresToDistances', () => {
 
   it('falls back to shift conversion for unknown metric', () => {
     expect(scoresToDistances([3, 1], null)).toEqual([0, 2]);
-  });
-});
-
-describe('densifyKnnGraph', () => {
-  const graph = {
-    // knn edges: 0 -> 1 (0.9), 1 -> 2 (0.8), 1 -> 0 (0.7)
-    offsets_row: [0, 1, 1],
-    offsets_col: [1, 2, 0],
-    scores: [0.9, 0.8, 0.7],
-    ids: ['a', 'b', 'c'],
-  };
-
-  it('produces a symmetric matrix with zero diagonal', () => {
-    const matrix = densifyKnnGraph(graph, 'Cosine');
-
-    expect(matrix.length).toEqual(3);
-    for (let i = 0; i < 3; i++) {
-      expect(matrix[i].length).toEqual(3);
-      expect(matrix[i][i]).toEqual(0);
-      for (let j = 0; j < 3; j++) {
-        expect(matrix[i][j]).toEqual(matrix[j][i]);
-      }
-    }
-  });
-
-  it('keeps the smallest distance when both directions are present', () => {
-    const matrix = densifyKnnGraph(graph, 'Cosine');
-
-    // cosine distances: 0->1 is 0.1, 1->0 is 0.3, min wins
-    expect(matrix[0][1]).toBeCloseTo(0.1);
-    expect(matrix[1][0]).toBeCloseTo(0.1);
-    expect(matrix[1][2]).toBeCloseTo(0.2);
-  });
-
-  it('fills missing pairs with a penalty larger than any observed distance', () => {
-    const matrix = densifyKnnGraph(graph, 'Cosine');
-
-    const maxObserved = 0.3; // cosine distance of the 1 -> 0 edge
-    expect(matrix[0][2]).toBeGreaterThan(maxObserved);
-    expect(matrix[0][2]).toEqual(matrix[2][0]);
-  });
-
-  it('squares distances when requested', () => {
-    const plain = densifyKnnGraph(graph, 'Cosine');
-    const squared = densifyKnnGraph(graph, 'Cosine', { squared: true });
-
-    expect(squared[0][1]).toBeCloseTo(plain[0][1] * plain[0][1]);
-    expect(squared[0][2]).toBeCloseTo(plain[0][2] * plain[0][2]);
-  });
-
-  it('ignores self-loops', () => {
-    const withLoop = {
-      offsets_row: [0, 0],
-      offsets_col: [0, 1],
-      scores: [1, 0.5],
-      ids: ['a', 'b'],
-    };
-    const matrix = densifyKnnGraph(withLoop, 'Cosine');
-    expect(matrix[0][0]).toEqual(0);
-    expect(matrix[0][1]).toBeCloseTo(0.5);
   });
 });
 

--- a/src/pages/Visualize.jsx
+++ b/src/pages/Visualize.jsx
@@ -1,7 +1,19 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Paper, Box, Tooltip, Typography, Grid, IconButton, Tabs, Tab } from '@mui/material';
-import { ArrowBack } from '@mui/icons-material';
+import {
+  Paper,
+  Box,
+  Tooltip,
+  Typography,
+  Grid,
+  IconButton,
+  Tabs,
+  Tab,
+  List,
+  ListItemButton,
+  alpha,
+} from '@mui/material';
+import { ArrowBack, Visibility, VisibilityOff } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import FilterEditorWindow from '../components/FilterEditorWindow';
@@ -11,7 +23,14 @@ import PointPreview from '../components/Common/PointPreview';
 import TabPanel from '../components/Common/TabPanel';
 import { useClient } from '../context/client-context';
 import { requestData } from '../components/VisualizeChart/requestData';
+import { getSimilarPoints } from '../lib/graph-visualization-helpers';
 import { useSnackbar } from 'notistack';
+
+// Lazy: SelectionPanel pulls in @mui/x-data-grid (~90 KB gzipped), which is
+// only needed once the user makes a selection
+const SelectionPanel = React.lazy(() => import('../components/VisualizeChart/SelectionPanel'));
+
+const SIMILAR_POINTS_LIMIT = 12;
 
 const query = `
 
@@ -51,6 +70,26 @@ const query = `
 // - 'algorithm': specify algorithm to use for visualization.
 //                Available options: 'UMAP' (default), 'TSNE',
 //                'PCA' (loads raw vectors into the browser).
+//
+// - 'perplexity': TSNE only, effective number of neighbors per point.
+//                 The request automatically fetches 3x this many
+//                 neighbors from the server. Default: derived
+//                 from 'n_neighbors'.
+//
+// - 'highlight': emphasize points matching a filter, dim the rest:
+//
+//                "highlight": {
+//                  "filter": { ... }
+//                }
+//
+// Chart interactions:
+//
+// - click a point to see its payload and its nearest neighbors
+// - shift+drag to select points: the selection is emphasized and
+//   the Selection tab opens, where selected points can be inspected
+//   and copied (ids, JSON or a ready-to-use filter);
+//   close the selection tag to reset it
+// - drag to pan, mouse wheel to zoom
 
 
 `;
@@ -69,10 +108,28 @@ function Visualize() {
   const navigate = useNavigate();
   const params = useParams();
   const [visualizeChartHeight, setVisualizeChartHeight] = useState(0);
+  const [panelsHeight, setPanelsHeight] = useState(0);
   const VisualizeChartWrapper = useRef(null);
+  const panelsWrapper = useRef(null);
   const { height } = useWindowResize();
   const [activePoint, setActivePoint] = useState(null);
+  const [similarPoints, setSimilarPoints] = useState(null);
+  const [selectedPoints, setSelectedPoints] = useState(null);
   const [tabValue, setTabValue] = useState(0);
+  // True while the distance-matrix request is in flight, before any layout
+  // work starts - the first request can be slow, so surface it right away
+  const [fetching, setFetching] = useState(false);
+
+  // Ids currently sampled into the visualization. Similar points are queried
+  // against the whole collection (a sample-restricted filter would be huge),
+  // so some neighbors are not part of what is drawn - mark them as such
+  const sampledIds = useMemo(() => new Set((result.points ?? []).map((point) => String(point.id))), [result]);
+
+  const clearSelection = () => {
+    setSelectedPoints(null);
+    // Leave the Selection tab if it was active, it is about to disappear
+    setTabValue((prev) => (prev === 2 ? 0 : prev));
+  };
 
   const handleTabChange = (event, newValue) => {
     setTabValue(newValue);
@@ -80,7 +137,12 @@ function Visualize() {
 
   useEffect(() => {
     setVisualizeChartHeight(height - VisualizeChartWrapper.current?.offsetTop);
-  }, [height, VisualizeChartWrapper]);
+    // Bound the whole split-pane area to the viewport, so an overly long
+    // Data Panel scrolls inside its own pane instead of the whole page
+    if (panelsWrapper.current) {
+      setPanelsHeight(height - panelsWrapper.current.getBoundingClientRect().top);
+    }
+  }, [height, VisualizeChartWrapper, panelsWrapper]);
 
   useEffect(() => {
     if (activePoint != null && tabValue !== 1) {
@@ -90,14 +152,71 @@ function Visualize() {
 
   const onEditorCodeRun = async (data, collectionName) => {
     setVisualizationParams(data);
+    setActivePoint(null);
+    setSimilarPoints(null);
+    clearSelection();
+    setFetching(true);
 
     try {
       const result = await requestData(qdrantClient, collectionName, data);
       setResult(result);
     } catch (e) {
       enqueueSnackbar(`Request error: ${e.message}`, { variant: 'error' });
+    } finally {
+      setFetching(false);
     }
   };
+
+  // Click on a point: show it in the Data Panel and highlight its
+  // nearest neighbors, served live by Qdrant
+  const onPointSelect = async (point) => {
+    if (!point) {
+      setActivePoint(null);
+      setSimilarPoints(null);
+      return;
+    }
+    setActivePoint(point);
+    setSimilarPoints(null);
+    try {
+      const neighbors = await getSimilarPoints(qdrantClient, {
+        collectionName: params.collectionName,
+        pointId: point.id,
+        limit: SIMILAR_POINTS_LIMIT,
+        filter: visualizationParams?.filter ?? undefined,
+        using: visualizationParams?.using ?? undefined,
+      });
+      setSimilarPoints(neighbors);
+    } catch (e) {
+      enqueueSnackbar(`Failed to load similar points: ${e.message}`, { variant: 'error' });
+    }
+  };
+
+  // Shift+drag: the selection becomes the working set - selected points
+  // stay bright, the rest is dimmed, and the Selection tab opens with
+  // the list of selected points
+  const onBoxSelect = (points) => {
+    if (!points.length) {
+      clearSelection();
+      return;
+    }
+    setSelectedPoints(points);
+    setTabValue(2);
+  };
+
+  // Points to emphasize in the chart, by precedence: the active selection,
+  // then the neighbors of the clicked point, then the 'highlight' filter
+  let focusIds = null;
+  if (selectedPoints?.length) {
+    focusIds = selectedPoints.map((point) => point.id);
+  } else if (similarPoints && activePoint) {
+    focusIds = [activePoint.id, ...similarPoints.map((point) => point.id)];
+  } else if (result?.highlightIds?.length) {
+    focusIds = result.highlightIds;
+  }
+
+  // The clicked point gets a distinct marker, but not while a box selection
+  // (which has no single "current" point) is the active emphasis
+  const selectedId = !selectedPoints?.length && activePoint ? activePoint.id : null;
 
   const filterRequestSchema = (vectorNames) => ({
     description: 'Filter request',
@@ -169,6 +288,23 @@ function Visualize() {
         enum: ['UMAP', 'TSNE', 'PCA'],
         default: 'UMAP',
       },
+      perplexity: {
+        description:
+          'TSNE only: effective number of neighbors per point. 3x this many neighbors are requested from the server',
+        type: 'number',
+        minimum: 2,
+        nullable: true,
+      },
+      highlight: {
+        description: 'Emphasize points matching a filter, dim the rest',
+        type: 'object',
+        properties: {
+          filter: {
+            $ref: '#/components/schemas/Filter',
+          },
+        },
+        nullable: true,
+      },
     },
   });
 
@@ -183,89 +319,162 @@ function Visualize() {
           {/*    </Grid>*/}
           {/*  )}*/}
           <Grid size={12}>
-            <PanelGroup direction="horizontal">
-              <Panel style={{ display: 'flex' }}>
-                <Box width={'100%'}>
-                  <Box>
-                    <Paper
-                      variant="heading"
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        p: 1,
-                        borderRadius: 0,
-                        borderBottom: `1px solid ${theme.palette.divider}`,
-                      }}
-                    >
-                      <Tooltip title={'Back to collection'}>
-                        <IconButton
-                          sx={{ mr: 3 }}
-                          size="small"
-                          onClick={() => navigate(`/collections/${encodeURIComponent(params.collectionName)}`)}
-                        >
-                          <ArrowBack />
-                        </IconButton>
-                      </Tooltip>
-                      <Typography variant="h6">{params.collectionName}</Typography>
-                    </Paper>
+            <Box ref={panelsWrapper} sx={{ height: panelsHeight || 'auto', overflow: 'hidden' }}>
+              <PanelGroup direction="horizontal" style={{ height: '100%' }}>
+                <Panel style={{ display: 'flex' }}>
+                  <Box width={'100%'}>
+                    <Box>
+                      <Paper
+                        variant="heading"
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          p: 1,
+                          borderRadius: 0,
+                          borderBottom: `1px solid ${theme.palette.divider}`,
+                        }}
+                      >
+                        <Tooltip title={'Back to collection'}>
+                          <IconButton
+                            sx={{ mr: 3 }}
+                            size="small"
+                            onClick={() => navigate(`/collections/${encodeURIComponent(params.collectionName)}`)}
+                          >
+                            <ArrowBack />
+                          </IconButton>
+                        </Tooltip>
+                        <Typography variant="h6">{params.collectionName}</Typography>
+                      </Paper>
+                    </Box>
+                    <Box ref={VisualizeChartWrapper} height={visualizeChartHeight} width={'100%'}>
+                      <VisualizeChart
+                        requestResult={result}
+                        visualizationParams={visualizationParams}
+                        fetching={fetching}
+                        onPointSelect={onPointSelect}
+                        onBoxSelect={onBoxSelect}
+                        focusIds={focusIds}
+                        selectedId={selectedId}
+                        selectionCount={selectedPoints?.length ?? 0}
+                        onSelectionClear={clearSelection}
+                      />
+                    </Box>
                   </Box>
-                  <Box ref={VisualizeChartWrapper} height={visualizeChartHeight} width={'100%'}>
-                    <VisualizeChart
-                      requestResult={result}
-                      visualizationParams={visualizationParams}
-                      activePoint={activePoint}
-                      setActivePoint={setActivePoint}
-                    />
-                  </Box>
-                </Box>
-              </Panel>
-              <PanelResizeHandle
-                style={{
-                  width: '10px',
-                  background: theme.palette.background.paperElevation2,
-                }}
-              >
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    height: '100%',
+                </Panel>
+                <PanelResizeHandle
+                  style={{
+                    width: '10px',
+                    background: theme.palette.background.paperElevation2,
                   }}
                 >
-                  &#8942;
-                </Box>
-              </PanelResizeHandle>
-              <Panel>
-                <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
                   <Box
                     sx={{
-                      borderBottom: 1,
-                      borderColor: 'divider',
-                      backgroundColor: theme.palette.background.paper,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      height: '100%',
                     }}
                   >
-                    <Tabs value={tabValue} onChange={handleTabChange} aria-label="visualization tabs">
-                      <Tab label="Code" />
-                      <Tab label="Data Panel" />
-                    </Tabs>
+                    &#8942;
                   </Box>
-                  <TabPanel value={tabValue} index={0} style={{ flex: 1, overflow: 'hidden' }}>
-                    <FilterEditorWindow
-                      code={code}
-                      onChange={setCode}
-                      onChangeResult={onEditorCodeRun}
-                      customRequestSchema={filterRequestSchema}
-                    />
-                  </TabPanel>
-                  <TabPanel value={tabValue} index={1} style={{ flex: 1, overflow: 'hidden' }}>
-                    <Box sx={{ height: '100%', overflowY: 'scroll' }}>
-                      <PointPreview point={activePoint} />
+                </PanelResizeHandle>
+                <Panel>
+                  <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+                    <Box
+                      sx={{
+                        borderBottom: 1,
+                        borderColor: 'divider',
+                        backgroundColor: theme.palette.background.paper,
+                      }}
+                    >
+                      <Tabs value={tabValue} onChange={handleTabChange} aria-label="visualization tabs">
+                        <Tab label="Code" value={0} />
+                        <Tab label="Data Panel" value={1} />
+                        {selectedPoints?.length > 0 && <Tab label={`Selection (${selectedPoints.length})`} value={2} />}
+                      </Tabs>
                     </Box>
-                  </TabPanel>
-                </Box>
-              </Panel>
-            </PanelGroup>
+                    <TabPanel value={tabValue} index={0} style={{ flex: 1, overflow: 'hidden' }}>
+                      <FilterEditorWindow
+                        code={code}
+                        onChange={setCode}
+                        onChangeResult={onEditorCodeRun}
+                        customRequestSchema={filterRequestSchema}
+                      />
+                    </TabPanel>
+                    <TabPanel value={tabValue} index={1} style={{ flex: 1, overflow: 'hidden' }}>
+                      <Box sx={{ height: '100%', overflowY: 'scroll' }}>
+                        <PointPreview point={activePoint} />
+                        {similarPoints && similarPoints.length > 0 && (
+                          <Box sx={{ borderTop: `1px solid ${alpha(theme.palette.text.primary, 0.12)}` }}>
+                            {/* Match the section-header treatment used in PointPreview */}
+                            <Box
+                              component="header"
+                              sx={{
+                                backgroundColor: alpha(theme.palette.action.hover, 0.08),
+                                px: 2,
+                                py: 0.5,
+                                display: 'flex',
+                                alignItems: 'center',
+                                height: 48,
+                              }}
+                            >
+                              <Typography variant="h6">Similar points</Typography>
+                            </Box>
+                            <List dense disablePadding sx={{ py: 1 }}>
+                              {similarPoints.map((point) => {
+                                const inSample = sampledIds.has(String(point.id));
+                                return (
+                                  <ListItemButton
+                                    key={String(point.id)}
+                                    onClick={() => onPointSelect(point)}
+                                    sx={{
+                                      display: 'flex',
+                                      justifyContent: 'space-between',
+                                      gap: 1,
+                                      px: 2,
+                                      opacity: inSample ? 1 : 0.55,
+                                    }}
+                                  >
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+                                      <Tooltip
+                                        title={
+                                          inSample
+                                            ? 'Shown in the visualization'
+                                            : 'Not among the sampled points, so it is not shown in the chart'
+                                        }
+                                      >
+                                        {inSample ? (
+                                          <Visibility fontSize="small" color="action" />
+                                        ) : (
+                                          <VisibilityOff fontSize="small" color="disabled" />
+                                        )}
+                                      </Tooltip>
+                                      <Typography variant="body2" noWrap>
+                                        Point {String(point.id)}
+                                      </Typography>
+                                    </Box>
+                                    <Typography variant="body2" color="text.secondary">
+                                      {typeof point.score === 'number' ? point.score.toFixed(4) : ''}
+                                    </Typography>
+                                  </ListItemButton>
+                                );
+                              })}
+                            </List>
+                          </Box>
+                        )}
+                      </Box>
+                    </TabPanel>
+                    {selectedPoints?.length > 0 && (
+                      <TabPanel value={tabValue} index={2} style={{ flex: 1, overflow: 'hidden' }}>
+                        <React.Suspense fallback={null}>
+                          <SelectionPanel points={selectedPoints} onPointClick={onPointSelect} />
+                        </React.Suspense>
+                      </TabPanel>
+                    )}
+                  </Box>
+                </Panel>
+              </PanelGroup>
+            </Box>
           </Grid>
         </Grid>
       </Box>


### PR DESCRIPTION
## What

Third milestone of the Scale Visualization effort, stacked on #408. Replaces the Chart.js scatter with `ScatterGL`, a small hand-written WebGL2 renderer (~450 lines, no new dependencies) in `src/components/VisualizeChart/ScatterGL.js`.

Chart.js was the remaining scale ceiling after M1/M2: with the wasm engine laying out 20k+ points, a 2D-canvas chart that rebuilds datasets per animation frame cannot keep up. ScatterGL renders all points from one `Float32Array` (a layout frame is a single `bufferSubData` upload + one draw call) and comfortably handles the point counts the wasm engine produces.

## Features

- **Pan & zoom** — drag to pan, wheel for cursor-anchored zoom; neither existed with Chart.js. Auto-fits during the layout animation, stops auto-fitting once the user takes over.
- **Exact hit-testing** — offscreen picking framebuffer with color-encoded ids: hover tooltip (`Point <id>`), hovered-point emphasis, click/hover → Data Panel, same as before but pixel-exact at any point count.
- **Legend parity** — HTML legend for `color_by` payload groups with show/hide toggling (replacing the Chart.js legend behavior).
- **Worker protocol** — positions now stream as transferable flat `Float32Array`s instead of arrays of `{x, y}` objects (zero-copy handoff; the DruidJS TSNE/PCA paths are converted to the same format).
- Fixes a latent `Math.min(...scores)` stack-overflow risk for large query-colored results in `renderBy.js`.

`chart.js` remains a dependency — the collection Optimizations timeline still uses it; only the Visualize tab is migrated.

## Testing

- Full suite (142 tests), lint and production build pass.
- Verified in headless Chrome against a live Qdrant with a 3 000-point / 3-cluster collection: layout renders colored clusters, hover shows the tooltip and populates the Data Panel with the right payload, cursor-anchored wheel zoom resolves individual points at the anchor, legend toggle strikes through and hides the group, no console errors (screenshots in the PR conversation on request).

Part of the Scale Visualization plan (M3 of 4). Next: nearest-neighbor highlight, lasso selection, isolate-to-editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)