### PR TITLE
Visualization: remove DruidJS — wasm TSNE + own PCA (Scale Viz M5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@mui/x-data-grid": "^7.29.1",
         "@qdrant/graph-layout-wasm": "github:qdrant/graph-layout-wasm#master",
         "@qdrant/js-client-rest": "^1.15.1",
-        "@saehrimnir/druidjs": "^0.6.3",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -1806,8 +1805,8 @@
       }
     },
     "node_modules/@qdrant/graph-layout-wasm": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/qdrant/graph-layout-wasm.git#e70ea04a8e6d04f1a17c9fd3b18bdc3f43958c4d",
+      "version": "0.2.0",
+      "resolved": "git+ssh://git@github.com/qdrant/graph-layout-wasm.git#25ac7c69e1549c0dd2ff9b9b3b1c2d285a34df0f",
       "license": "Apache-2.0"
     },
     "node_modules/@qdrant/js-client-rest": {
@@ -2195,13 +2194,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@saehrimnir/druidjs": {
-      "version": "0.6.3",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/@sevinf/maybe": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@mui/x-data-grid": "^7.29.1",
     "@qdrant/graph-layout-wasm": "github:qdrant/graph-layout-wasm#master",
     "@qdrant/js-client-rest": "^1.15.1",
-    "@saehrimnir/druidjs": "^0.6.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/components/VisualizeChart/ScatterGL.js
+++ b/src/components/VisualizeChart/ScatterGL.js
@@ -35,14 +35,22 @@ void main() {
 const POINT_FRAGMENT_SHADER = `#version 300 es
 precision highp float;
 in vec4 v_color;
+uniform float u_ring;      // 0 = filled disc, 1 = ring outline (selected marker)
+uniform vec4 u_ringColor;  // ring color, used only when u_ring == 1
 out vec4 outColor;
 void main() {
   vec2 c = gl_PointCoord - vec2(0.5);
   float dist = length(c);
   if (dist > 0.5) discard;
-  // Soft edge
-  float alpha = v_color.a * smoothstep(0.5, 0.42, dist);
-  outColor = vec4(v_color.rgb * alpha, alpha);
+  if (u_ring > 0.5) {
+    // Annulus: opaque near the rim, hollow in the middle
+    float a = u_ringColor.a * smoothstep(0.30, 0.40, dist) * smoothstep(0.5, 0.44, dist);
+    outColor = vec4(u_ringColor.rgb * a, a);
+  } else {
+    // Soft edge
+    float alpha = v_color.a * smoothstep(0.5, 0.42, dist);
+    outColor = vec4(v_color.rgb * alpha, alpha);
+  }
 }`;
 
 const PICKING_FRAGMENT_SHADER = `#version 300 es
@@ -115,6 +123,10 @@ export default class ScatterGL {
 
     this.hoveredIndex = null;
     this.highlightIndex = null;
+    // The clicked point, drawn enlarged with a contrasting ring so it stands
+    // out from its (also emphasized) nearest neighbors
+    this.selectedIndex = null;
+    this.selectedRing = [1, 1, 1, 1];
     this.renderScheduled = false;
     this.pickingDirty = true;
     this.destroyed = false;
@@ -171,6 +183,7 @@ export default class ScatterGL {
     this.tween = null;
     this.hoveredIndex = null;
     this.highlightIndex = null;
+    this.selectedIndex = null;
     this.userAdjustedView = false;
 
     // Picking colors encode index + 1 as RGB (0 = background)
@@ -379,13 +392,28 @@ export default class ScatterGL {
     gl.bindVertexArray(this.vao);
     gl.uniform2fv(gl.getUniformLocation(this.program, 'u_scale'), this.viewScale);
     gl.uniform2fv(gl.getUniformLocation(this.program, 'u_offset'), this.viewOffset);
-    gl.uniform1f(gl.getUniformLocation(this.program, 'u_pointSize'), this.pointSizePx());
+    const uPointSize = gl.getUniformLocation(this.program, 'u_pointSize');
+    const uRing = gl.getUniformLocation(this.program, 'u_ring');
+    gl.uniform1f(uRing, 0);
+    gl.uniform1f(uPointSize, this.pointSizePx());
     gl.drawArrays(gl.POINTS, 0, this.n);
 
     // Emphasize the hovered point by re-drawing it larger
     if (this.highlightIndex !== null && this.highlightIndex < this.n) {
-      gl.uniform1f(gl.getUniformLocation(this.program, 'u_pointSize'), this.pointSizePx() * 1.8);
+      gl.uniform1f(uPointSize, this.pointSizePx() * 1.8);
       gl.drawArrays(gl.POINTS, this.highlightIndex, 1);
+    }
+
+    // Mark the selected point: redraw it larger in its own color, then wrap it
+    // in a contrasting ring so it is distinct from the emphasized neighbors
+    if (this.selectedIndex !== null && this.selectedIndex < this.n) {
+      gl.uniform1f(uPointSize, this.pointSizePx() * 1.5);
+      gl.drawArrays(gl.POINTS, this.selectedIndex, 1);
+      gl.uniform1f(uRing, 1);
+      gl.uniform4fv(gl.getUniformLocation(this.program, 'u_ringColor'), this.selectedRing);
+      gl.uniform1f(uPointSize, this.pointSizePx() * 2.6);
+      gl.drawArrays(gl.POINTS, this.selectedIndex, 1);
+      gl.uniform1f(uRing, 0);
     }
     gl.bindVertexArray(null);
   }
@@ -393,6 +421,19 @@ export default class ScatterGL {
   setHighlight(index) {
     if (index !== this.highlightIndex) {
       this.highlightIndex = index;
+      this.requestRender();
+    }
+  }
+
+  // Mark a single point as selected (the clicked one). `color` is a CSS color
+  // string for the ring; pass null as index to clear the marker.
+  setSelected(index, color) {
+    if (color) {
+      const c = chroma(color).rgba();
+      this.selectedRing = [c[0] / 255, c[1] / 255, c[2] / 255, c[3]];
+    }
+    if (index !== this.selectedIndex || color) {
+      this.selectedIndex = index;
       this.requestRender();
     }
   }

--- a/src/components/VisualizeChart/index.jsx
+++ b/src/components/VisualizeChart/index.jsx
@@ -123,7 +123,7 @@ const VisualizeChart = ({
         }
       } else {
         setProgress(null);
-        enqueueSnackbar(`Visualization Unsuccessful, error: Unexpected Error Occured`, { variant: 'error' });
+        enqueueSnackbar(`Visualization Unsuccessful, error: Unexpected Error Occurred`, { variant: 'error' });
       }
     };
 

--- a/src/components/VisualizeChart/index.jsx
+++ b/src/components/VisualizeChart/index.jsx
@@ -9,6 +9,7 @@ import { generateColorBy, generateGroupsAndColors } from './renderBy';
 const VisualizeChart = ({
   requestResult, // Raw output of the request from qdrant client
   visualizationParams, // Parameters, as specified by the user in the input editor
+  fetching, // true while the distance-matrix request is in flight (before layout)
   onPointSelect, // callback: point clicked (null for a click on empty space)
   onBoxSelect, // callback: array of points selected with shift+drag
   focusIds, // ids of points to emphasize (all others get dimmed), or null
@@ -245,20 +246,33 @@ const VisualizeChart = ({
           sx={{ position: 'absolute', bottom: 8, right: 8, zIndex: 2 }}
         />
       )}
-      {progress && (
-        <Tooltip title="Layout is running, press to stop it and keep the current picture">
+      {/* Fetching takes precedence over any stale progress from the previous
+          run's worker, which keeps animating until the new result arrives */}
+      {fetching ? (
+        <Tooltip title="Requesting data from Qdrant, this can take a while on the first request">
           <Chip
             size="small"
             variant="outlined"
-            label={
-              progress.total
-                ? `Layout: ${Math.round((progress.step / progress.total) * 100)}%`
-                : `Layout: iteration ${progress.step}`
-            }
-            onDelete={stopLayout}
+            label="Requesting data…"
             sx={{ position: 'absolute', bottom: 8, left: 8, zIndex: 2, backdropFilter: 'blur(2px)' }}
           />
         </Tooltip>
+      ) : (
+        progress && (
+          <Tooltip title="Layout is running, press to stop it and keep the current picture">
+            <Chip
+              size="small"
+              variant="outlined"
+              label={
+                progress.total
+                  ? `Layout: ${Math.round((progress.step / progress.total) * 100)}%`
+                  : `Layout: iteration ${progress.step}`
+              }
+              onDelete={stopLayout}
+              sx={{ position: 'absolute', bottom: 8, left: 8, zIndex: 2, backdropFilter: 'blur(2px)' }}
+            />
+          </Tooltip>
+        )
       )}
       <canvas ref={canvasRef} style={{ width: '100%', height: '100%', display: 'block' }} />
       {boxRect && (
@@ -302,6 +316,7 @@ const VisualizeChart = ({
 VisualizeChart.propTypes = {
   requestResult: PropTypes.object.isRequired,
   visualizationParams: PropTypes.object.isRequired,
+  fetching: PropTypes.bool,
   onPointSelect: PropTypes.func,
   onBoxSelect: PropTypes.func,
   focusIds: PropTypes.array,

--- a/src/components/VisualizeChart/index.jsx
+++ b/src/components/VisualizeChart/index.jsx
@@ -13,6 +13,7 @@ const VisualizeChart = ({
   onPointSelect, // callback: point clicked (null for a click on empty space)
   onBoxSelect, // callback: array of points selected with shift+drag
   focusIds, // ids of points to emphasize (all others get dimmed), or null
+  selectedId, // id of the single clicked point, marked distinctly, or null
   selectionCount, // number of points in the active selection, if any
   onSelectionClear, // callback: the selection chip was closed
 }) => {
@@ -181,6 +182,20 @@ const VisualizeChart = ({
     scatter.setFocus(indices);
   }, [focusIds, requestResult]);
 
+  // Mark the single clicked point distinctly from its highlighted neighbors
+  useEffect(() => {
+    const scatter = scatterRef.current;
+    if (!scatter || scatter.n === 0) {
+      return;
+    }
+    if (selectedId === null || selectedId === undefined) {
+      scatter.setSelected(null, theme.palette.text.primary);
+      return;
+    }
+    const index = pointsRef.current.findIndex((point) => String(point.id) === String(selectedId));
+    scatter.setSelected(index >= 0 ? index : null, theme.palette.text.primary);
+  }, [selectedId, requestResult, theme.palette.text.primary]);
+
   const toggleGroup = (label) => {
     setHiddenGroups((prev) => {
       const next = new Set(prev);
@@ -320,6 +335,7 @@ VisualizeChart.propTypes = {
   onPointSelect: PropTypes.func,
   onBoxSelect: PropTypes.func,
   focusIds: PropTypes.array,
+  selectedId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   selectionCount: PropTypes.number,
   onSelectionClear: PropTypes.func,
 };

--- a/src/components/VisualizeChart/pca.js
+++ b/src/components/VisualizeChart/pca.js
@@ -1,0 +1,103 @@
+// Principal component analysis, used by the visualization worker for the
+// 'PCA' algorithm - the one path that still consumes raw vectors.
+
+// Deterministic PRNG for reproducible PCA sign/orientation
+function mulberry32(seed) {
+  let a = seed;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Project onto the top-2 principal components via power iteration on the
+// centered data. Never forms the covariance matrix: each iteration is
+// w = X_c^T (X_c v), O(n * d)
+export function pca2d(vectors) {
+  const n = vectors.length;
+  const d = vectors[0].length;
+
+  const mean = new Float64Array(d);
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < d; j++) {
+      mean[j] += vectors[i][j];
+    }
+  }
+  for (let j = 0; j < d; j++) {
+    mean[j] /= n;
+  }
+
+  const rand = mulberry32(42);
+  const components = [];
+
+  for (let c = 0; c < 2; c++) {
+    let v = new Float64Array(d);
+    for (let j = 0; j < d; j++) {
+      v[j] = rand() - 0.5;
+    }
+    orthonormalize(v, components);
+
+    for (let iter = 0; iter < 64; iter++) {
+      const w = new Float64Array(d);
+      for (let i = 0; i < n; i++) {
+        const row = vectors[i];
+        let dot = 0;
+        for (let j = 0; j < d; j++) {
+          dot += (row[j] - mean[j]) * v[j];
+        }
+        for (let j = 0; j < d; j++) {
+          w[j] += (row[j] - mean[j]) * dot;
+        }
+      }
+      orthonormalize(w, components);
+
+      let agreement = 0;
+      for (let j = 0; j < d; j++) {
+        agreement += w[j] * v[j];
+      }
+      v = w;
+      if (Math.abs(1 - Math.abs(agreement)) < 1e-9) {
+        break;
+      }
+    }
+    components.push(v);
+  }
+
+  const positions = new Float32Array(n * 2);
+  for (let i = 0; i < n; i++) {
+    const row = vectors[i];
+    for (let c = 0; c < 2; c++) {
+      let dot = 0;
+      for (let j = 0; j < d; j++) {
+        dot += (row[j] - mean[j]) * components[c][j];
+      }
+      positions[i * 2 + c] = dot;
+    }
+  }
+  return positions;
+}
+
+// Remove projections onto previous components, then normalize
+function orthonormalize(v, components) {
+  const d = v.length;
+  for (const component of components) {
+    let dot = 0;
+    for (let j = 0; j < d; j++) {
+      dot += v[j] * component[j];
+    }
+    for (let j = 0; j < d; j++) {
+      v[j] -= dot * component[j];
+    }
+  }
+  let norm = 0;
+  for (let j = 0; j < d; j++) {
+    norm += v[j] * v[j];
+  }
+  norm = Math.sqrt(norm) || 1;
+  for (let j = 0; j < d; j++) {
+    v[j] /= norm;
+  }
+}

--- a/src/components/VisualizeChart/requestData.js
+++ b/src/components/VisualizeChart/requestData.js
@@ -1,41 +1,36 @@
 /* eslint-disable camelcase */
 import { DEFAULT_N_NEIGHBORS, resolveDistanceMetric } from '../../lib/knn-graph';
 
-// Preferred data source: server-side distance matrix (Qdrant >= 1.12).
-// Qdrant samples `limit` points and computes a knn graph between them,
-// so raw vectors never have to be transferred to the browser.
-// Falls back to the legacy scroll-with-vectors request for older servers
-// and for PCA, which needs the raw vectors.
+// Data source for the visualization: the server-side distance matrix
+// (Qdrant >= 1.12). Qdrant samples `limit` points and computes a knn graph
+// between them, so raw vectors never have to be transferred to the browser.
+//
+// The one exception is PCA, which fundamentally needs the raw vectors and
+// is fed by a plain scroll request.
 
 export async function requestData(qdrantClient, collectionName, params) {
-  const { algorithm = null } = params;
-
-  if (algorithm === 'PCA') {
-    // PCA operates on raw vectors, there is nothing to precompute server-side
+  if (params.algorithm === 'PCA') {
     return await requestRawVectors(qdrantClient, collectionName, params);
   }
-
-  try {
-    return await requestMatrixData(qdrantClient, collectionName, params);
-  } catch (e) {
-    if (isMatrixApiUnsupported(e)) {
-      // Qdrant < 1.12 does not have the distance matrix API
-      return await requestRawVectors(qdrantClient, collectionName, params);
-    }
-    throw e;
-  }
+  return await requestMatrixData(qdrantClient, collectionName, params);
 }
 
 async function requestMatrixData(
   qdrantClient,
   collectionName,
-  { limit, filter = null, using = null, color_by = null, n_neighbors = null, highlight = null }
+  { limit, filter = null, using = null, color_by = null, n_neighbors = null, perplexity = null, highlight = null }
 ) {
+  // t-SNE convention: the Gaussian kernel wants ~3x perplexity neighbors
+  let knnLimit = n_neighbors ?? DEFAULT_N_NEIGHBORS;
+  if (perplexity != null) {
+    knnLimit = Math.max(knnLimit, Math.ceil(3 * perplexity));
+  }
+
   const [collectionInfo, matrixResponse] = await Promise.all([
     qdrantClient.getCollection(collectionName),
     qdrantClient.searchMatrixOffsets(collectionName, {
       sample: limit,
-      limit: n_neighbors ?? DEFAULT_N_NEIGHBORS,
+      limit: knnLimit,
       filter,
       using: using ?? undefined,
     }),
@@ -113,22 +108,22 @@ async function requestMatrixData(
   };
 }
 
+// Raw vectors, PCA only
 async function requestRawVectors(
   qdrantClient,
   collectionName,
   { limit, filter = null, using = null, color_by = null }
 ) {
-  if (color_by?.query) {
-    const query = {
+  if (color_by != null && color_by.query !== undefined && color_by.query !== null) {
+    // Score-based coloring: the query provides both vectors and scores
+    return await qdrantClient.query(collectionName, {
       query: color_by.query,
       limit: limit,
       filter: filter,
       with_vector: using ? [using] : true,
       with_payload: true,
-      using: using ?? null,
-    };
-
-    return await qdrantClient.query(collectionName, query);
+      using: using ?? undefined,
+    });
   }
 
   const scrollQuery = {
@@ -139,12 +134,4 @@ async function requestRawVectors(
   };
 
   return await qdrantClient.scroll(collectionName, scrollQuery);
-}
-
-function isMatrixApiUnsupported(error) {
-  const status = error?.status ?? error?.response?.status;
-  if (status === 404 || status === 501) {
-    return true;
-  }
-  return /not found/i.test(String(error?.message ?? ''));
 }

--- a/src/components/VisualizeChart/tests/pca.test.js
+++ b/src/components/VisualizeChart/tests/pca.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { pca2d } from '../pca';
+
+describe('pca2d', () => {
+  it('projects onto the directions of maximal variance', () => {
+    // Points on a diagonal line in 3D with small orthogonal noise:
+    // the first component must capture the diagonal
+    const points = [];
+    for (let i = 0; i < 50; i++) {
+      const t = i - 25;
+      points.push([t, t, t + Math.sin(i * 7.3) * 0.01]);
+    }
+    const projected = pca2d(points);
+
+    // Order along the first component matches order along the line
+    // (up to a global sign)
+    const xs = [];
+    for (let i = 0; i < 50; i++) {
+      xs.push(projected[i * 2]);
+    }
+    const increasing = xs.every((x, i) => i === 0 || x > xs[i - 1]);
+    const decreasing = xs.every((x, i) => i === 0 || x < xs[i - 1]);
+    expect(increasing || decreasing).toBe(true);
+
+    // Second component only carries the noise
+    const spreadY =
+      Math.max(...xs.map((_, i) => projected[i * 2 + 1])) - Math.min(...xs.map((_, i) => projected[i * 2 + 1]));
+    const spreadX = Math.max(...xs) - Math.min(...xs);
+    expect(spreadY).toBeLessThan(spreadX / 10);
+  });
+
+  it('separates two clusters along the first component', () => {
+    const points = [];
+    for (let i = 0; i < 40; i++) {
+      const offset = i < 20 ? 0 : 8;
+      points.push([offset + Math.sin(i) * 0.3, offset + Math.cos(i) * 0.3, Math.sin(i * 2) * 0.3]);
+    }
+    const projected = pca2d(points);
+    const a = projected.filter((_, idx) => idx % 2 === 0).slice(0, 20);
+    const b = projected.filter((_, idx) => idx % 2 === 0).slice(20);
+    const meanA = a.reduce((s, v) => s + v, 0) / a.length;
+    const meanB = b.reduce((s, v) => s + v, 0) / b.length;
+    expect(Math.abs(meanA - meanB)).toBeGreaterThan(5);
+  });
+
+  it('is deterministic', () => {
+    const points = Array.from({ length: 30 }, (_, i) => [Math.sin(i * 1.7), Math.cos(i * 0.9), Math.sin(i * 2.3)]);
+    expect(pca2d(points)).toEqual(pca2d(points));
+  });
+});

--- a/src/components/VisualizeChart/worker.js
+++ b/src/components/VisualizeChart/worker.js
@@ -1,13 +1,9 @@
 /* eslint-disable no-restricted-globals */
-import * as druid from '@saehrimnir/druidjs';
 import get from 'lodash/get';
-import initWasm, { UmapLayout } from '@qdrant/graph-layout-wasm';
+import initWasm, { UmapLayout, TsneLayout, TsneParams } from '@qdrant/graph-layout-wasm';
 import wasmUrl from '@qdrant/graph-layout-wasm/pkg/graph_layout_wasm_bg.wasm?url';
-import { densifyKnnGraph, scoresToDistances } from '../../lib/knn-graph';
-
-// druid's TSNE with `metric: "precomputed"` references the bare name `druid`
-// inside its own bundle (upstream bug), so the module has to be exposed globally
-self.druid = druid;
+import { scoresToDistances } from '../../lib/knn-graph';
+import { pca2d } from './pca';
 
 let wasmReady = null;
 function ensureWasm() {
@@ -17,23 +13,8 @@ function ensureWasm() {
 
 const MESSAGE_INTERVAL = 200;
 const UMAP_EPOCHS_PER_CHUNK = 5;
+const TSNE_ITERATIONS_PER_CHUNK = 10;
 const DEFAULT_ALGORITHM = 'UMAP';
-
-function getVectorType(vector) {
-  if (Array.isArray(vector)) {
-    if (Array.isArray(vector[0])) {
-      return 'multivector';
-    }
-    return 'vector';
-  }
-  if (typeof vector === 'object') {
-    if (vector.indices) {
-      return 'sparse';
-    }
-    return 'named';
-  }
-  return 'unknown';
-}
 
 self.onmessage = async function (e) {
   const params = e?.data?.params || {};
@@ -42,8 +23,10 @@ self.onmessage = async function (e) {
   try {
     if (result.graph) {
       await handleKnnGraph(result, params);
+    } else if ((params.algorithm || DEFAULT_ALGORITHM) === 'PCA') {
+      handlePca(result, params);
     } else {
-      handleRawVectors(result, params);
+      self.postMessage({ data: [], error: 'No data found' });
     }
   } catch (error) {
     self.postMessage({ data: [], error: error?.message ?? String(error) });
@@ -70,83 +53,87 @@ async function handleKnnGraph(result, params) {
     return;
   }
 
-  if (algorithm === 'UMAP') {
-    // wasm layout consumes the sparse knn graph directly, no densification
-    await ensureWasm();
-    const distances = scoresToDistances(graph.scores, result.metric);
-    const layout = new UmapLayout(
-      n,
-      new Uint32Array(graph.offsets_row),
-      new Uint32Array(graph.offsets_col),
-      new Float32Array(distances),
-      undefined // default params: min_dist 0.1, auto epochs, fixed seed
-    );
+  await ensureWasm();
 
-    try {
-      let now = Date.now();
-      let done = false;
-      while (!done) {
-        done = layout.step(UMAP_EPOCHS_PER_CHUNK);
-        if (Date.now() - now > MESSAGE_INTERVAL) {
-          now = Date.now();
-          postPositions(layout.embedding(), {
-            step: layout.current_epoch(),
-            total: layout.n_epochs(),
-          });
-        }
-      }
-      postPositions(layout.embedding(), null, true);
-    } finally {
-      layout.free();
-    }
+  const rows = new Uint32Array(graph.offsets_row);
+  const cols = new Uint32Array(graph.offsets_col);
+  const distances = new Float32Array(scoresToDistances(graph.scores, result.metric));
+
+  let layout;
+  let chunk;
+  if (algorithm === 'UMAP') {
+    // default params: min_dist 0.1, auto epochs, fixed seed
+    layout = new UmapLayout(n, rows, cols, distances, undefined);
+    chunk = UMAP_EPOCHS_PER_CHUNK;
   } else if (algorithm === 'TSNE') {
-    // druid's TSNE defaults to squared euclidean, mirror that for precomputed distances
-    const matrix = densifyKnnGraph(graph, result.metric, { squared: true });
-    const perplexity = Math.max(2, Math.min(50, Math.floor((n - 1) / 3)));
-    const reducer = new druid.TSNE(matrix, { metric: 'precomputed', perplexity });
-    streamLayout(reducer);
+    const tsneParams = new TsneParams();
+    // The graph carries the neighbors the server was asked for; without an
+    // explicit perplexity, derive one from the actual graph degree
+    // (t-SNE convention: k = 3 x perplexity)
+    const avgDegree = Math.floor(graph.scores.length / n);
+    tsneParams.perplexity = params.perplexity ?? Math.min(30, Math.max(2, Math.floor(avgDegree / 3)));
+    layout = new TsneLayout(n, rows, cols, distances, tsneParams);
+    chunk = TSNE_ITERATIONS_PER_CHUNK;
   } else {
     self.postMessage({
       data: [],
       error: `${algorithm} does not support server-side distance matrix`,
     });
+    return;
+  }
+
+  try {
+    let now = Date.now();
+    let done = false;
+    while (!done) {
+      done = layout.step(chunk);
+      if (Date.now() - now > MESSAGE_INTERVAL) {
+        now = Date.now();
+        postPositions(layout.embedding(), {
+          step: layout.current_epoch(),
+          total: layout.n_epochs(),
+        });
+      }
+    }
+    postPositions(layout.embedding(), null, true);
+  } finally {
+    layout.free();
   }
 }
 
-// Send flat [x0, y0, x1, y1, ...] coordinates, transferring the buffer.
-// `progress` is { step, total } (total may be null when unknown),
-// `done` marks the final frame of the layout.
-function postPositions(positions, progress = null, done = false) {
-  const array = positions instanceof Float32Array ? positions : new Float32Array(positions);
-  self.postMessage({ result: array, progress, done, error: null }, [array.buffer]);
+function getVectorType(vector) {
+  if (Array.isArray(vector)) {
+    if (Array.isArray(vector[0])) {
+      return 'multivector';
+    }
+    return 'vector';
+  }
+  if (typeof vector === 'object') {
+    if (vector.indices) {
+      return 'sparse';
+    }
+    return 'named';
+  }
+  return 'unknown';
 }
 
-// Legacy path: dimensionality reduction on raw vectors, loaded into the browser.
-// Used for PCA and as a fallback for Qdrant versions without the matrix API.
-function handleRawVectors(result, params) {
-  const algorithm = params.algorithm || DEFAULT_ALGORITHM;
-
-  const data = [];
-
+// PCA fundamentally needs the raw vectors (there is nothing to precompute
+// server-side), so it is the one algorithm still fed by a scroll request
+function handlePca(result, params) {
   const points = result.points;
   const vectorName = params.using;
 
   if (!points || points.length === 0) {
-    self.postMessage({
-      data: [],
-      error: 'No data found',
-    });
+    self.postMessage({ data: [], error: 'No data found' });
     return;
   }
 
   if (points.length === 1) {
-    self.postMessage({
-      data: [],
-      error: `cannot perform ${algorithm} on single point`,
-    });
+    self.postMessage({ data: [], error: 'cannot perform PCA on single point' });
     return;
   }
 
+  const data = [];
   for (let i = 0; i < points.length; i++) {
     if (!vectorName) {
       // Work with default vector
@@ -157,16 +144,11 @@ function handleRawVectors(result, params) {
     }
   }
 
-  // Validate data
-
   for (let i = 0; i < data.length; i++) {
-    const vector = data[i];
-    const vectorType = getVectorType(vector);
-
+    const vectorType = getVectorType(data[i]);
     if (vectorType === 'vector') {
       continue;
     }
-
     if (vectorType === 'named') {
       self.postMessage({
         data: [],
@@ -174,7 +156,6 @@ function handleRawVectors(result, params) {
       });
       return;
     }
-
     self.postMessage({
       data: [],
       error: 'Vector visualization is not supported for vector type: ' + vectorType,
@@ -182,43 +163,12 @@ function handleRawVectors(result, params) {
     return;
   }
 
-  if (data.length) {
-    if (algorithm === 'PCA') {
-      const D = new druid[algorithm](data, {});
-      const transformedData = D.transform();
-
-      postPositions(flatten(transformedData), null, true);
-    } else {
-      const D = new druid[algorithm](data, {}); // ex  params = { perplexity : 50,epsilon :5}
-      streamLayout(D);
-    }
-  }
+  postPositions(pca2d(data), null, true);
 }
 
-// Run the iterative layout, streaming intermediate results for animation
-function streamLayout(reducer) {
-  let now = Date.now();
-  const next = reducer.generator(); // default = 500 iterations
-
-  let reducedPoints = [];
-  let step = 0;
-  for (reducedPoints of next) {
-    step++;
-    if (Date.now() - now > MESSAGE_INTERVAL) {
-      now = Date.now();
-      // druid's generator does not expose its total, report steps only
-      postPositions(flatten(reducedPoints), { step, total: null });
-    }
-  }
-  postPositions(flatten(reducedPoints), null, true);
-}
-
-// Convert [[x1, y1], [x2, y2], ...] to flat [x1, y1, x2, y2, ...]
-function flatten(reducedPoints) {
-  const flat = new Float32Array(reducedPoints.length * 2);
-  for (let i = 0; i < reducedPoints.length; i++) {
-    flat[i * 2] = reducedPoints[i][0];
-    flat[i * 2 + 1] = reducedPoints[i][1];
-  }
-  return flat;
+// Send flat [x0, y0, x1, y1, ...] coordinates, transferring the buffer.
+// `progress` is { step, total }, `done` marks the final frame of the layout.
+function postPositions(positions, progress = null, done = false) {
+  const array = positions instanceof Float32Array ? positions : new Float32Array(positions);
+  self.postMessage({ result: array, progress, done, error: null }, [array.buffer]);
 }

--- a/src/lib/knn-graph.js
+++ b/src/lib/knn-graph.js
@@ -38,48 +38,6 @@ export function scoresToDistances(scores, metric) {
   }
 }
 
-// Expand the sparse knn graph from the matrix/offsets response into a dense,
-// symmetric distance matrix (as an array of rows), suitable for DruidJS
-// with `metric: "precomputed"`. Pairs absent from the knn graph get a penalty
-// distance larger than any observed one.
-//
-// Note: this densification is O(n²) memory and is a temporary bridge until
-// the layout can consume the sparse graph directly.
-export function densifyKnnGraph(graph, metric, { squared = false } = {}) {
-  const { offsets_row, offsets_col, scores, ids } = graph;
-  const n = ids.length;
-
-  const distances = scoresToDistances(scores, metric);
-
-  const maxDistance = distances.length > 0 ? arrayMax(distances) : 0;
-  let fillValue = (maxDistance > 0 ? maxDistance : 1) * 2;
-  if (squared) {
-    fillValue *= fillValue;
-  }
-
-  const matrix = new Array(n);
-  for (let i = 0; i < n; i++) {
-    matrix[i] = new Array(n).fill(fillValue);
-    matrix[i][i] = 0;
-  }
-
-  for (let k = 0; k < distances.length; k++) {
-    const i = offsets_row[k];
-    const j = offsets_col[k];
-    if (i === j) {
-      continue;
-    }
-    const distance = squared ? distances[k] * distances[k] : distances[k];
-    // Symmetrize, keeping the smaller distance if both directions are present
-    if (distance < matrix[i][j]) {
-      matrix[i][j] = distance;
-      matrix[j][i] = distance;
-    }
-  }
-
-  return matrix;
-}
-
 // Figure out the distance metric of the vector used for visualization
 // from the collection info. Returns null if it cannot be determined.
 export function resolveDistanceMetric(collectionInfo, using = null) {

--- a/src/lib/tests/knn-graph.test.js
+++ b/src/lib/tests/knn-graph.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { describe, it, expect } from 'vitest';
-import { scoresToDistances, densifyKnnGraph, resolveDistanceMetric } from '../knn-graph';
+import { scoresToDistances, resolveDistanceMetric } from '../knn-graph';
 
 describe('scoresToDistances', () => {
   it('converts cosine similarity to distance', () => {
@@ -22,66 +22,6 @@ describe('scoresToDistances', () => {
 
   it('falls back to shift conversion for unknown metric', () => {
     expect(scoresToDistances([3, 1], null)).toEqual([0, 2]);
-  });
-});
-
-describe('densifyKnnGraph', () => {
-  const graph = {
-    // knn edges: 0 -> 1 (0.9), 1 -> 2 (0.8), 1 -> 0 (0.7)
-    offsets_row: [0, 1, 1],
-    offsets_col: [1, 2, 0],
-    scores: [0.9, 0.8, 0.7],
-    ids: ['a', 'b', 'c'],
-  };
-
-  it('produces a symmetric matrix with zero diagonal', () => {
-    const matrix = densifyKnnGraph(graph, 'Cosine');
-
-    expect(matrix.length).toEqual(3);
-    for (let i = 0; i < 3; i++) {
-      expect(matrix[i].length).toEqual(3);
-      expect(matrix[i][i]).toEqual(0);
-      for (let j = 0; j < 3; j++) {
-        expect(matrix[i][j]).toEqual(matrix[j][i]);
-      }
-    }
-  });
-
-  it('keeps the smallest distance when both directions are present', () => {
-    const matrix = densifyKnnGraph(graph, 'Cosine');
-
-    // cosine distances: 0->1 is 0.1, 1->0 is 0.3, min wins
-    expect(matrix[0][1]).toBeCloseTo(0.1);
-    expect(matrix[1][0]).toBeCloseTo(0.1);
-    expect(matrix[1][2]).toBeCloseTo(0.2);
-  });
-
-  it('fills missing pairs with a penalty larger than any observed distance', () => {
-    const matrix = densifyKnnGraph(graph, 'Cosine');
-
-    const maxObserved = 0.3; // cosine distance of the 1 -> 0 edge
-    expect(matrix[0][2]).toBeGreaterThan(maxObserved);
-    expect(matrix[0][2]).toEqual(matrix[2][0]);
-  });
-
-  it('squares distances when requested', () => {
-    const plain = densifyKnnGraph(graph, 'Cosine');
-    const squared = densifyKnnGraph(graph, 'Cosine', { squared: true });
-
-    expect(squared[0][1]).toBeCloseTo(plain[0][1] * plain[0][1]);
-    expect(squared[0][2]).toBeCloseTo(plain[0][2] * plain[0][2]);
-  });
-
-  it('ignores self-loops', () => {
-    const withLoop = {
-      offsets_row: [0, 0],
-      offsets_col: [0, 1],
-      scores: [1, 0.5],
-      ids: ['a', 'b'],
-    };
-    const matrix = densifyKnnGraph(withLoop, 'Cosine');
-    expect(matrix[0][0]).toEqual(0);
-    expect(matrix[0][1]).toBeCloseTo(0.5);
   });
 });
 

--- a/src/pages/Visualize.jsx
+++ b/src/pages/Visualize.jsx
@@ -209,6 +209,10 @@ function Visualize() {
     focusIds = result.highlightIds;
   }
 
+  // The clicked point gets a distinct marker, but not while a box selection
+  // (which has no single "current" point) is the active emphasis
+  const selectedId = !selectedPoints?.length && activePoint ? activePoint.id : null;
+
   const filterRequestSchema = (vectorNames) => ({
     description: 'Filter request',
     type: 'object',
@@ -345,6 +349,7 @@ function Visualize() {
                         onPointSelect={onPointSelect}
                         onBoxSelect={onBoxSelect}
                         focusIds={focusIds}
+                        selectedId={selectedId}
                         selectionCount={selectedPoints?.length ?? 0}
                         onSelectionClear={clearSelection}
                       />

--- a/src/pages/Visualize.jsx
+++ b/src/pages/Visualize.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   Paper,
@@ -13,7 +13,7 @@ import {
   ListItemButton,
   alpha,
 } from '@mui/material';
-import { ArrowBack } from '@mui/icons-material';
+import { ArrowBack, Visibility, VisibilityOff } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import FilterEditorWindow from '../components/FilterEditorWindow';
@@ -119,6 +119,11 @@ function Visualize() {
   // True while the distance-matrix request is in flight, before any layout
   // work starts - the first request can be slow, so surface it right away
   const [fetching, setFetching] = useState(false);
+
+  // Ids currently sampled into the visualization. Similar points are queried
+  // against the whole collection (a sample-restricted filter would be huge),
+  // so some neighbors are not part of what is drawn - mark them as such
+  const sampledIds = useMemo(() => new Set((result.points ?? []).map((point) => String(point.id))), [result]);
 
   const clearSelection = () => {
     setSelectedPoints(null);
@@ -416,18 +421,44 @@ function Visualize() {
                               <Typography variant="h6">Similar points</Typography>
                             </Box>
                             <List dense disablePadding sx={{ py: 1 }}>
-                              {similarPoints.map((point) => (
-                                <ListItemButton
-                                  key={String(point.id)}
-                                  onClick={() => onPointSelect(point)}
-                                  sx={{ display: 'flex', justifyContent: 'space-between', px: 2 }}
-                                >
-                                  <Typography variant="body2">Point {String(point.id)}</Typography>
-                                  <Typography variant="body2" color="text.secondary">
-                                    {typeof point.score === 'number' ? point.score.toFixed(4) : ''}
-                                  </Typography>
-                                </ListItemButton>
-                              ))}
+                              {similarPoints.map((point) => {
+                                const inSample = sampledIds.has(String(point.id));
+                                return (
+                                  <ListItemButton
+                                    key={String(point.id)}
+                                    onClick={() => onPointSelect(point)}
+                                    sx={{
+                                      display: 'flex',
+                                      justifyContent: 'space-between',
+                                      gap: 1,
+                                      px: 2,
+                                      opacity: inSample ? 1 : 0.55,
+                                    }}
+                                  >
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+                                      <Tooltip
+                                        title={
+                                          inSample
+                                            ? 'Shown in the visualization'
+                                            : 'Not among the sampled points, so it is not shown in the chart'
+                                        }
+                                      >
+                                        {inSample ? (
+                                          <Visibility fontSize="small" color="action" />
+                                        ) : (
+                                          <VisibilityOff fontSize="small" color="disabled" />
+                                        )}
+                                      </Tooltip>
+                                      <Typography variant="body2" noWrap>
+                                        Point {String(point.id)}
+                                      </Typography>
+                                    </Box>
+                                    <Typography variant="body2" color="text.secondary">
+                                      {typeof point.score === 'number' ? point.score.toFixed(4) : ''}
+                                    </Typography>
+                                  </ListItemButton>
+                                );
+                              })}
                             </List>
                           </Box>
                         )}

--- a/src/pages/Visualize.jsx
+++ b/src/pages/Visualize.jsx
@@ -1,6 +1,18 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Paper, Box, Tooltip, Typography, Grid, IconButton, Tabs, Tab, List, ListItemButton } from '@mui/material';
+import {
+  Paper,
+  Box,
+  Tooltip,
+  Typography,
+  Grid,
+  IconButton,
+  Tabs,
+  Tab,
+  List,
+  ListItemButton,
+  alpha,
+} from '@mui/material';
 import { ArrowBack } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
@@ -383,16 +395,27 @@ function Visualize() {
                       <Box sx={{ height: '100%', overflowY: 'scroll' }}>
                         <PointPreview point={activePoint} />
                         {similarPoints && similarPoints.length > 0 && (
-                          <Box sx={{ px: 2, pb: 2 }}>
-                            <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                              Similar points
-                            </Typography>
-                            <List dense disablePadding>
+                          <Box sx={{ borderTop: `1px solid ${alpha(theme.palette.text.primary, 0.12)}` }}>
+                            {/* Match the section-header treatment used in PointPreview */}
+                            <Box
+                              component="header"
+                              sx={{
+                                backgroundColor: alpha(theme.palette.action.hover, 0.08),
+                                px: 2,
+                                py: 0.5,
+                                display: 'flex',
+                                alignItems: 'center',
+                                height: 48,
+                              }}
+                            >
+                              <Typography variant="h6">Similar points</Typography>
+                            </Box>
+                            <List dense disablePadding sx={{ py: 1 }}>
                               {similarPoints.map((point) => (
                                 <ListItemButton
                                   key={String(point.id)}
                                   onClick={() => onPointSelect(point)}
-                                  sx={{ display: 'flex', justifyContent: 'space-between' }}
+                                  sx={{ display: 'flex', justifyContent: 'space-between', px: 2 }}
                                 >
                                   <Typography variant="body2">Point {String(point.id)}</Typography>
                                   <Typography variant="body2" color="text.secondary">

--- a/src/pages/Visualize.jsx
+++ b/src/pages/Visualize.jsx
@@ -59,6 +59,11 @@ const query = `
 //                Available options: 'UMAP' (default), 'TSNE',
 //                'PCA' (loads raw vectors into the browser).
 //
+// - 'perplexity': TSNE only, effective number of neighbors per point.
+//                 The request automatically fetches 3x this many
+//                 neighbors from the server. Default: derived
+//                 from 'n_neighbors'.
+//
 // - 'highlight': emphasize points matching a filter, dim the rest:
 //
 //                "highlight": {
@@ -255,6 +260,13 @@ function Visualize() {
         type: 'string',
         enum: ['UMAP', 'TSNE', 'PCA'],
         default: 'UMAP',
+      },
+      perplexity: {
+        description:
+          'TSNE only: effective number of neighbors per point. 3x this many neighbors are requested from the server',
+        type: 'number',
+        minimum: 2,
+        nullable: true,
       },
       highlight: {
         description: 'Emphasize points matching a filter, dim the rest',

--- a/src/pages/Visualize.jsx
+++ b/src/pages/Visualize.jsx
@@ -104,6 +104,9 @@ function Visualize() {
   const [similarPoints, setSimilarPoints] = useState(null);
   const [selectedPoints, setSelectedPoints] = useState(null);
   const [tabValue, setTabValue] = useState(0);
+  // True while the distance-matrix request is in flight, before any layout
+  // work starts - the first request can be slow, so surface it right away
+  const [fetching, setFetching] = useState(false);
 
   const clearSelection = () => {
     setSelectedPoints(null);
@@ -135,12 +138,15 @@ function Visualize() {
     setActivePoint(null);
     setSimilarPoints(null);
     clearSelection();
+    setFetching(true);
 
     try {
       const result = await requestData(qdrantClient, collectionName, data);
       setResult(result);
     } catch (e) {
       enqueueSnackbar(`Request error: ${e.message}`, { variant: 'error' });
+    } finally {
+      setFetching(false);
     }
   };
 
@@ -323,6 +329,7 @@ function Visualize() {
                       <VisualizeChart
                         requestResult={result}
                         visualizationParams={visualizationParams}
+                        fetching={fetching}
                         onPointSelect={onPointSelect}
                         onBoxSelect={onBoxSelect}
                         focusIds={focusIds}


### PR DESCRIPTION
## What

Removes `@saehrimnir/druidjs` entirely, completing the algorithm-engine migration. Stacked on #410.

- **TSNE → wasm.** [`graph-layout-wasm` v0.2.0](https://github.com/qdrant/graph-layout-wasm) adds Barnes-Hut t-SNE with the same streaming `step()` API as UMAP: per-row perplexity calibration from the sparse knn distances, symmetrized sparse affinities, O(N log N) quadtree repulsion, early exaggeration / momentum switch / per-coordinate gains per van der Maaten's reference implementation. The O(n²) densified-matrix bridge (`densifyKnnGraph`) and the `self.druid` global workaround for DruidJS's broken `precomputed` path are both deleted.
- **New `perplexity` config option** (TSNE): the matrix request automatically fetches 3× perplexity neighbors (t-SNE convention). Without it, perplexity is derived from the actual graph degree, so the default `n_neighbors: 15` keeps working.
- **PCA → own implementation.** ~80 lines of power iteration on the centered data (`pca.js`) — never forms the covariance matrix, O(n·d) per iteration, deterministic (fixed-seed init), unit-tested. PCA remains the one algorithm fed by raw vectors via scroll, including query-score coloring.
- **Pre-1.12 fallback removed** (per discussion): UMAP/TSNE now require the Distance Matrix API. Matrix-endpoint errors surface directly instead of silently falling back to a raw-vector path.

## Impact

- TSNE scale ceiling moves from ~2k points (dense DruidJS math) to the same class as UMAP: 20k points / 300k edges in ~12 s native (~1 s for 1.5k points in the browser), streamed with progress + stop.
- Every layout path is now deterministic per seed.
- Worker chunk sheds DruidJS (−48 KB gzipped).

## Testing

- Crate: 5 new t-SNE tests (cluster separation, determinism + chunk invariance, finite embeddings, duplicate-coordinate quadtree robustness, degenerate inputs); 11 total, clippy/fmt clean, CI green.
- Web-ui: 3 new PCA unit tests; suite (140), lint, and production build pass.
- Verified all three algorithms in headless Chrome against a live Qdrant (3 000-point / 3-cluster collection): TSNE produces three cleanly separated clusters, PCA the expected concentric linear projection, UMAP unchanged; progress chips cycle correctly; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)