### PR TITLE
indexing buttons for array fields

### DIFF
--- a/src/components/Points/PointPayload.jsx
+++ b/src/components/Points/PointPayload.jsx
@@ -10,6 +10,7 @@ import { PayloadEditor } from './PayloadEditor';
 import PayloadIndexDialog from './PayloadIndexDialog';
 import {
   makePayloadIndexValueTypes,
+  payloadIndexKeyRenderer,
   PayloadIndexColorspaceProvider,
   IndexActionProvider,
   HoverFieldProvider,
@@ -122,6 +123,7 @@ const PointPayload = ({
                     rootName={false}
                     enableClipboard={true}
                     valueTypes={showIndexButton ? valueTypes : undefined}
+                    keyRenderer={showIndexButton ? payloadIndexKeyRenderer : undefined}
                   />
                 </Box>
               </HoverFieldProvider>

--- a/src/components/Points/makePayloadIndexValueTypes.jsx
+++ b/src/components/Points/makePayloadIndexValueTypes.jsx
@@ -1,7 +1,9 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Box, Tooltip } from '@mui/material';
 import { Database, DatabaseZap } from 'lucide-react';
 import PropTypes from 'prop-types';
+import { pathToIndexName, isArrayIndexSegment } from '../../lib/payload-index-helpers';
 
 // ColorspaceContext — compute colors outside json-viewer's ThemeProvider and pass them in.
 // (The json-viewer bundles its own MUI v5, so useTheme() inside valueTypes Components
@@ -77,64 +79,80 @@ NativeValueRenderer.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool, PropTypes.oneOf([null])]),
 };
 
-const PayloadIndexComponent = ({ value, path }) => {
+// The index button (or "already indexed" indicator) shown while its row is hovered.
+// Mirrors json-viewer's IconBox (the copy button wrapper): an inline span with the
+// same padding and icon size, so both icons line up.
+const PayloadIndexButton = ({ path, sampleValue }) => {
   const colors = useContext(ColorspaceContext) || {};
   const indexAction = useContext(IndexActionContext);
   const activeField = useContext(HoverFieldContext);
 
-  const fieldName = path.join('.');
+  // Row identity for hover tracking keeps the raw path ("items.0.sku"),
+  // while the index acts on the Qdrant field name ("items[].sku").
+  const rowKey = path.join('.');
+  const fieldName = pathToIndexName(path);
   const indexedType = indexAction?.getIndexType(fieldName);
-  const isRowActive = activeField === fieldName;
 
-  return (
-    <>
-      <NativeValueRenderer value={value} />
-      {indexAction &&
-        isRowActive &&
-        // Mirrors json-viewer's IconBox (the copy button wrapper): an inline span with the
-        // same padding and icon size, so both icons line up.
-        (indexedType ? (
-          <Tooltip title={`Indexed: ${indexedType} — click to edit or delete the index`} placement="top">
-            <Box
-              component="span"
-              role="button"
-              aria-label={`Edit index for ${fieldName} (${indexedType})`}
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                indexAction.open(fieldName, value);
-              }}
-              sx={{
-                cursor: 'pointer',
-                paddingLeft: '0.7rem',
-                color: colors.base0D || 'inherit',
-              }}
-            >
-              <DatabaseZap size="0.8rem" />
-            </Box>
-          </Tooltip>
-        ) : (
-          <Box
-            component="span"
-            role="button"
-            aria-label={`Create index for ${fieldName}`}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              indexAction.open(fieldName, value);
-            }}
-            sx={{
-              cursor: 'pointer',
-              paddingLeft: '0.7rem',
-              color: colors.base0D || 'inherit',
-            }}
-          >
-            <Database size="0.8rem" />
-          </Box>
-        ))}
-    </>
+  // Like json-viewer's own copy button, a row counts as hovered while the
+  // cursor is on it or on any of its descendants (relevant for array rows).
+  const isRowActive = activeField === rowKey || (activeField !== null && activeField.startsWith(`${rowKey}.`));
+
+  if (!indexAction || !isRowActive) {
+    return null;
+  }
+
+  return indexedType ? (
+    <Tooltip title={`Indexed: ${indexedType} — click to edit or delete the index`} placement="top">
+      <Box
+        component="span"
+        role="button"
+        aria-label={`Edit index for ${fieldName} (${indexedType})`}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          indexAction.open(fieldName, sampleValue);
+        }}
+        sx={{
+          cursor: 'pointer',
+          paddingLeft: '0.7rem',
+          color: colors.base0D || 'inherit',
+        }}
+      >
+        <DatabaseZap size="0.8rem" />
+      </Box>
+    </Tooltip>
+  ) : (
+    <Box
+      component="span"
+      role="button"
+      aria-label={`Create index for ${fieldName}`}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        indexAction.open(fieldName, sampleValue);
+      }}
+      sx={{
+        cursor: 'pointer',
+        paddingLeft: '0.7rem',
+        color: colors.base0D || 'inherit',
+      }}
+    >
+      <Database size="0.8rem" />
+    </Box>
   );
 };
+
+PayloadIndexButton.propTypes = {
+  path: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
+  sampleValue: PropTypes.any,
+};
+
+const PayloadIndexComponent = ({ value, path }) => (
+  <>
+    <NativeValueRenderer value={value} />
+    <PayloadIndexButton path={path} sampleValue={value} />
+  </>
+);
 
 PayloadIndexComponent.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool, PropTypes.oneOf([null])]),
@@ -145,27 +163,64 @@ function isPrimitive(value) {
   return value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
 }
 
-function hasNumericSegment(path) {
-  return path.some((segment) => typeof segment === 'number' || (typeof segment === 'string' && /^\d+$/.test(segment)));
-}
-
 /**
  * Returns a valueTypes array for @textea/json-viewer that adds a hover "create index"
- * button to every primitive leaf field in point payload; already indexed fields get
- * an indicator with the index type instead.
+ * button to primitive leaf fields in point payload, including fields inside arrays
+ * of objects (indexed via the "items[].sku" notation). Elements of primitive arrays
+ * are skipped — the index button for those sits on the array row itself (see
+ * payloadIndexKeyRenderer). Already indexed fields get an indicator with the index
+ * type instead.
  *
  * @return {Array} valueTypes
  */
 export function makePayloadIndexValueTypes() {
   return [
     {
-      is: (value, path) => {
-        if (!isPrimitive(value)) return false;
-        if (path.length === 0) return false;
-        if (hasNumericSegment(path)) return false;
-        return true;
-      },
+      is: (value, path) => isPrimitive(value) && path.length > 0 && !isArrayIndexSegment(path[path.length - 1]),
       Component: PayloadIndexComponent,
     },
   ];
 }
+
+// Renders the key of an array-of-primitives row ("sections": […]) with the index
+// button attached, since the index for such arrays targets the array field itself
+// and the elements' value renderers are skipped. Objects inside arrays keep their
+// per-field buttons instead.
+//
+// The key renderer output is placed at the start of the ".data-key" span, before
+// the colon, while json-viewer renders the opening bracket and its hover copy icon
+// later in the same span. To match plain fields (index icon first, copy icon after),
+// the button is portaled into a dedicated span inserted right after the bracket —
+// appending to the span itself would race with the copy icon's mount order.
+const PayloadIndexKeyRenderer = ({ path, value }) => {
+  const anchorRef = useRef(null);
+  const [buttonHost, setButtonHost] = useState(null);
+
+  useEffect(() => {
+    const keySpan = anchorRef.current?.closest('.data-key');
+    if (!keySpan) return undefined;
+    const bracket = keySpan.querySelector(':scope > .data-object-start');
+    const host = document.createElement('span');
+    keySpan.insertBefore(host, bracket ? bracket.nextSibling : null);
+    setButtonHost(host);
+    return () => host.remove();
+  }, []);
+
+  return (
+    <>
+      &quot;{path[path.length - 1]}&quot;
+      <span ref={anchorRef} style={{ display: 'none' }} />
+      {buttonHost && createPortal(<PayloadIndexButton path={path} sampleValue={value.find(isPrimitive)} />, buttonHost)}
+    </>
+  );
+};
+
+PayloadIndexKeyRenderer.when = ({ value, path }) =>
+  Array.isArray(value) && path.length > 0 && !isArrayIndexSegment(path[path.length - 1]) && value.some(isPrimitive);
+
+PayloadIndexKeyRenderer.propTypes = {
+  path: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
+  value: PropTypes.array.isRequired,
+};
+
+export const payloadIndexKeyRenderer = PayloadIndexKeyRenderer;

--- a/src/lib/payload-index-helpers.js
+++ b/src/lib/payload-index-helpers.js
@@ -67,9 +67,37 @@ export function suggestFieldType(value) {
 }
 
 /**
- * Collect indexable leaf fields from a point payload as dot-notation paths,
- * each with a sample value for type suggestion. Array elements share the
- * parent path (numeric segments are not part of index field names).
+ * Whether a json-viewer path segment is an array index.
+ *
+ * @param {string|number} segment - path segment
+ * @return {boolean} true for array indices
+ */
+export function isArrayIndexSegment(segment) {
+  return typeof segment === 'number' || (typeof segment === 'string' && /^\d+$/.test(segment));
+}
+
+/**
+ * Convert a json-viewer path into a Qdrant index field name. Array indices are
+ * folded into the [] notation ("items[].sku") — plain dots would create an
+ * index that matches nothing. An index on array elements themselves targets
+ * the array field, so trailing brackets are dropped ("tags").
+ *
+ * @param {Array} path - json-viewer path segments (strings and array indices)
+ * @return {string} Qdrant index field name
+ */
+export function pathToIndexName(path) {
+  const name = path.reduce((acc, segment) => {
+    if (isArrayIndexSegment(segment)) return `${acc}[]`;
+    return acc ? `${acc}.${segment}` : String(segment);
+  }, '');
+  return name.replace(/(\[\])+$/, '');
+}
+
+/**
+ * Collect indexable leaf fields from a point payload, each with a sample value
+ * for type suggestion. Arrays of primitives are indexed at the array path
+ * ("tags"); fields inside arrays of objects use the [] notation required by
+ * Qdrant ("items[].sku") — plain dots would create an index that matches nothing.
  *
  * @param {Object} payload - point payload object
  * @param {Array} prefix - current path segments (used for recursion)
@@ -90,7 +118,7 @@ export function extractPayloadLeafFields(payload, prefix = []) {
       const sample = value.find((item) => item === null || PRIMITIVE_TYPES.includes(typeof item));
       if (sample !== undefined) add([{ name: path.join('.'), value: sample }]);
       const nested = value.find((item) => item && typeof item === 'object' && !Array.isArray(item));
-      if (nested) add(extractPayloadLeafFields(nested, path));
+      if (nested) add(extractPayloadLeafFields(nested, [...prefix, `${key}[]`]));
     } else if (typeof value === 'object') {
       add(extractPayloadLeafFields(value, path));
     }

--- a/src/lib/tests/payload-index-helpers.test.js
+++ b/src/lib/tests/payload-index-helpers.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { payloadFieldFormToIndexConfig, suggestFieldType, extractPayloadLeafFields } from '../payload-index-helpers';
+import {
+  payloadFieldFormToIndexConfig,
+  suggestFieldType,
+  extractPayloadLeafFields,
+  pathToIndexName,
+} from '../payload-index-helpers';
 import { createPayloadIndexParams } from '../../components/Collections/CreateCollection/create-collection';
 
 describe('payloadFieldFormToIndexConfig', () => {
@@ -138,14 +143,22 @@ describe('extractPayloadLeafFields', () => {
     ]);
   });
 
-  it('uses the parent path for array elements (no numeric segments)', () => {
+  it('indexes arrays of primitives at the array path', () => {
     const fields = extractPayloadLeafFields({
       tags: ['a', 'b'],
-      items: [{ sku: 'x1' }],
+    });
+    expect(fields).toEqual([{ name: 'tags', value: 'a' }]);
+  });
+
+  it('uses the [] notation for fields inside arrays of objects', () => {
+    const fields = extractPayloadLeafFields({
+      items: [{ sku: 'x1', variants: [{ color: 'red' }] }],
+      nested: { list: [{ id: 7 }] },
     });
     expect(fields).toEqual([
-      { name: 'tags', value: 'a' },
-      { name: 'items.sku', value: 'x1' },
+      { name: 'items[].sku', value: 'x1' },
+      { name: 'items[].variants[].color', value: 'red' },
+      { name: 'nested.list[].id', value: 7 },
     ]);
   });
 
@@ -156,5 +169,25 @@ describe('extractPayloadLeafFields', () => {
   it('returns an empty list for empty or missing payload', () => {
     expect(extractPayloadLeafFields({})).toEqual([]);
     expect(extractPayloadLeafFields(undefined)).toEqual([]);
+  });
+});
+
+describe('pathToIndexName', () => {
+  it('keeps plain object paths as dot notation', () => {
+    expect(pathToIndexName(['metadata', 'url'])).toBe('metadata.url');
+  });
+
+  it('targets the array field for primitive array elements', () => {
+    expect(pathToIndexName(['tags', 0])).toBe('tags');
+    expect(pathToIndexName(['tags', '1'])).toBe('tags');
+  });
+
+  it('folds array indices into the [] notation', () => {
+    expect(pathToIndexName(['items', 0, 'sku'])).toBe('items[].sku');
+    expect(pathToIndexName(['items', 2, 'variants', 1, 'color'])).toBe('items[].variants[].color');
+  });
+
+  it('handles arrays nested under objects', () => {
+    expect(pathToIndexName(['meta', 'list', 1])).toBe('meta.list');
   });
 });


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Index Buttons for Array Fields

Extends the payload indexing UI (#413, #414) to array fields, which previously got no
index button at all: paths containing an array index were excluded entirely, so fields
like `tags: ["a", "b"]` or `items: [{"sku": …}]` could not be indexed from the UI.

### What Changed

**Arrays of primitives** get the index button on the array row itself, next to the copy
icon — not on the individual elements:

```
"sections": [ 🗄 ⧉
  0: "articles"
  1: "articles/rag-is-dead"
]
```

Creating an index from this row targets the array field (`sections`), which is how
Qdrant indexes primitive arrays.

**Fields inside arrays of objects** get per-field buttons that use the `[]` notation
required by Qdrant: hovering `items[0].sku` offers an index on `items[].sku`. The new
`pathToIndexName()` helper converts json-viewer paths to Qdrant field names
(`['items', 0, 'sku']` → `items[].sku`, `['tags', 0]` → `tags`).

**Hover behavior** now matches the built-in copy button: the array row's button stays
visible while the cursor is over any of its child elements (prefix matching on the
hovered path), instead of disappearing as soon as the cursor leaves the key line.

### Bug Fix: Silently Broken Indexes from the Field Picker

`extractPayloadLeafFields()` (the Info tab field picker) generated dot-notation names
for fields inside arrays of objects (`items.sku`). Qdrant accepts such an index but it
matches nothing — verified against a live instance: `items.qty` reports `points: 0`
while `items[].qty` reports `points: 1`. The picker now emits the `[]` notation.

### Implementation Notes

- Buttons on array rows are injected via json-viewer's `keyRenderer`. Because the key
  renderer output sits before the colon while the copy icon is rendered after the
  opening bracket, the button is portaled into a dedicated span inserted right after
  the bracket element. This keeps the icon order (index, then copy) identical to plain
  fields and independent of mount timing.
- This relies on the DOM structure of the pinned `@textea/json-viewer@2.17.2`, in the
  same way the existing hover tracking already does (`data-testid` parsing). Worth
  re-verifying if the package is ever upgraded.

### Testing

- New unit tests for `pathToIndexName`; updated `extractPayloadLeafFields` tests for
  the `[]` notation (166 tests pass).
- Verified manually against a local Qdrant: create/edit/delete from array rows and
  array-of-object fields, indexed-state indicators, field picker options, and the
  resulting `payload_schema` keys and match counts on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)