### PR TITLE
Update Skills link in Welcome page

### DIFF
--- a/src/pages/Welcome.jsx
+++ b/src/pages/Welcome.jsx
@@ -87,9 +87,9 @@ const Welcome = () => {
               icon={BrainCircuit}
               title="Agent Skills"
               description={
-                'Download our AI Agent Skills, crafted by our team of experts to accelerate your development workflow.'
+                'Download our AI Agent Skills, crafted by our team of experts to strengthen your Qdrant development.'
               }
-              href="https://github.com/qdrant/skills"
+              href="https://qdrant.tech/documentation/skills/"
               showCta={false}
             />
           </Grid>


### PR DESCRIPTION
Qdrant Skills now has the meta-skill "Qdrant Advisor". Users should be routed to our documentation page explaining this skill, the skills.qdrant.tech page, and other details about our skills. This added context would be better than pointing directly to the repo.