### PR TITLE
Enable code folding in the console response panel

### DIFF
--- a/src/components/ResultEditorWindow/index.jsx
+++ b/src/components/ResultEditorWindow/index.jsx
@@ -22,7 +22,7 @@ const ResultEditorWindow = ({ code }) => {
         automaticLayout: true,
         readOnly: true,
         mouseWheelZoom: true,
-        folding: false,
+        folding: true,
         lineHeight: lineHeight,
         padding: { top: padding, bottom: padding },
       }}


### PR DESCRIPTION
## What

Turns on Monaco's code folding in the response (right-hand) pane of the Console, so long JSON responses can be collapsed block by block the way they can in a code editor.

Folding was explicitly disabled (`folding: false`) in the result editor, so the only way to navigate a large response was scrolling which can become very annoying if your collection/cluster/telemetry data is huge. 

```diff
-        folding: false,
+        folding: true,
```

## Notes

- No new dependency and no other options needed: `language="json"` already gives Monaco a folding-range provider (the JSON worker is wired up in `EditorCommon`), so the default `auto` strategy produces bracket-accurate fold ranges.
- Every other folding default is left alone, so the response pane now behaves exactly like the request pane: controls appear on gutter mouseover, and folded ranges are highlighted.
- The request editor is untouched — it never disabled folding, so it already had this.

## Test plan

- Ran a `points/scroll` query in the Console against a local Qdrant and confirmed the fold arrows appear in the response gutter on hover and collapse/expand nested objects and arrays.
- `prettier --check` and `eslint` pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)