### PR TITLE
fix: exclude all-zero-vector points from ANN Recall sample

### DIFF
--- a/src/components/Collections/SearchQuality/SearchQualityPanel.jsx
+++ b/src/components/Collections/SearchQuality/SearchQualityPanel.jsx
@@ -76,6 +76,11 @@ VectorTableRow.propTypes = {
 };
 
 const SAMPLE_SIZE = 100;
+// Over-fetch so all-zero-vector points (e.g. bookkeeping markers) can be dropped
+// and still leave SAMPLE_SIZE usable points. All-zero vectors score 0.0 against
+// everything, corrupting the recall average.
+const OVERFETCH_FACTOR = 2;
+const isZeroVector = (vec) => Array.isArray(vec) && vec.length > 0 && vec.every((v) => v === 0);
 
 const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo, ...other }) => {
   const { client } = useClient();
@@ -180,11 +185,12 @@ const SearchQualityPanel = ({ collectionName, vectors, loggingFoo, clearLogsFoo,
     try {
       const sampleResult = await client.scroll(collectionName, {
         with_payload: false,
-        with_vector: false,
-        limit: SAMPLE_SIZE,
+        with_vector: true,
+        limit: SAMPLE_SIZE * OVERFETCH_FACTOR,
       });
 
-      const pointIds = sampleResult.points.map((point) => point.id);
+      const usablePoints = sampleResult.points.filter((p) => !isZeroVector(p.vector));
+      const pointIds = usablePoints.slice(0, SAMPLE_SIZE).map((point) => point.id);
       const total = pointIds.length;
 
       loggingFoo &&

--- a/src/components/Collections/SearchQuality/searchQualityPannel.test.jsx
+++ b/src/components/Collections/SearchQuality/searchQualityPannel.test.jsx
@@ -84,6 +84,33 @@ describe('SearchQualityPannel', () => {
     });
   });
 
+  it('should exclude all-zero-vector points from the sample', async () => {
+    const scrollMock = vi.fn().mockResolvedValue({
+      points: [
+        { id: 'zero-marker', vector: [0, 0, 0] },
+        { id: 'normal-1', vector: [0.1, 0.2, 0.3] },
+      ],
+    });
+    const queryPointsMock = vi.fn().mockResolvedValue({
+      data: { result: { points: [{ id: 1 }, { id: 2 }] }, status: 'ok', time: 0.005 },
+    });
+    useClient.mockReturnValue({
+      client: { scroll: scrollMock, api: vi.fn().mockReturnValue({ queryPoints: queryPointsMock }) },
+    });
+
+    render(
+      <MemoryRouter>
+        <SearchQualityPanel collectionName={COLLECTION_NAME} vectors={VECTORS} />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getAllByTestId('index-quality-check-button')[0]);
+
+    await waitFor(() => expect(queryPointsMock).toHaveBeenCalled());
+    const queriedIds = queryPointsMock.mock.calls.map(([args]) => args.query);
+    expect(queriedIds).not.toContain('zero-marker');
+    expect(queriedIds).toContain('normal-1');
+  });
+
   it('should toggle advanced mode', () => {
     render(
       <MemoryRouter>


### PR DESCRIPTION
All-zero-vector points (e.g. bookkeeping markers) score `0.0` against every query, skewing the recall average in "Check Index Quality".

Over-fetches 2x and filters out all-zero vectors before taking `SAMPLE_SIZE`.

**Testing evidence:** verified against a live Qdrant cluster (6-shard test collection, 2000 points, 20 seeded all-zero vectors) that all-zero-vector points are returned in raw sample results and not excluded server-side — 10/20 appeared across 20 sample draws, confirming client-side filtering is required.

Added a test asserting a zero-vector point never reaches the recall-checking query. `npm run lint`, `npm run format:check`, and `npm test` (190/190) all pass.